### PR TITLE
Use released version of derive_builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,7 @@ errno = "0.2"
 error-chain = "0.10"
 ioctl-sys = "0.5.2"
 libc = "0.2"
-
-# At the moment we need stuff not in released derive_builder.
-# The fixes we need include compatibility with error-chain and the possibility
-# to use the #[builder(default)] feature.
-# TODO(linus): Use release when merged, or build our own builder
-[dependencies.derive_builder]
-git = "https://github.com/colin-kiegel/rust-derive-builder"
-branch = "feature/custom_default"
+derive_builder = "0.4"
 
 [build-dependencies]
 bindgen = "0.22"


### PR DESCRIPTION
They finally released the two features we needed from unstable branches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/5)
<!-- Reviewable:end -->
