### PR TITLE
Add PoolAddrList

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,9 @@ mod ffi;
 mod rule;
 pub use rule::*;
 
+mod pooladdr;
+pub use pooladdr::*;
+
 mod anchor;
 pub use anchor::*;
 

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -389,6 +389,31 @@ impl CopyToFfi<ffi::pfvar::pf_port_range> for Port {
     }
 }
 
+impl CopyToFfi<ffi::pfvar::pf_pool> for Port {
+    fn copy_to(&self, pf_pool: &mut ffi::pfvar::pf_pool) -> ::Result<()> {
+        match *self {
+            Port::Any => {
+                pf_pool.port_op = ffi::pfvar::PF_OP_NONE as u8;
+                pf_pool.proxy_port[0] = 0;
+                pf_pool.proxy_port[1] = 0;
+            }
+            Port::One(port, modifier) => {
+                pf_pool.port_op = modifier.to_ffi();
+                pf_pool.proxy_port[0] = port;
+                pf_pool.proxy_port[1] = 0;
+            }
+            Port::Range(start_port, end_port, modifier) => {
+                ensure!(start_port <= end_port,
+                        ::ErrorKind::InvalidArgument("Lower port is greater than upper port."));
+                pf_pool.port_op = modifier.to_ffi();
+                pf_pool.proxy_port[0] = start_port;
+                pf_pool.proxy_port[1] = end_port;
+            }
+        }
+        Ok(())
+    }
+}
+
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PortUnaryModifier {


### PR DESCRIPTION
This PR seeks to add safer way to work with linked lists used by PF in redirect/nat rules:

1. `PoolAddrList` that holds a list of `pf_pooladdr` and `pf_palist`. Both `pf_pooladdr` and `pf_palist` implement a linked list and internally use raw pointers and raw pointers-to-pointers therefore in order to prolong their lifetime we have to store them in Rust struct.

2. `palist_*` functions to manipulate `pf_palist` and `pf_pooladdr` to organize linked lists. This is direct translation from C TAILQ_* macros tailored to mentioned above structs. `palist_*` functions are separated from `PoolAddrList` for historical reasons, but I found it much easier to test this way, since `PoolAddrList` is immutable wrapper for `pf_palist`.

3. Adds `CopyToFfi` extension for `Port` to be able to translate to `pf_pool`. This is also used redirect/nat rules, it's slightly different implementation from `pf_port_range` because it expects to see port range in host byte order. `pf_pool` supports `port_op` however I never had a chance to test it and not sure how it works in context of redirect rules which I was working on as a part of larger task.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/11)
<!-- Reviewable:end -->
