### PR TITLE
Add rules flushing

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,7 @@ fn main() {
         .whitelisted_type("pf_status")
         .whitelisted_type("pfioc_rule")
         .whitelisted_type("pfioc_pooladdr")
+        .whitelisted_type("pfioc_trans")
         .whitelisted_var("PF_.*")
         .generate()
         .expect("Unable to generate bindings for pfvar.h")

--- a/src/anchor.rs
+++ b/src/anchor.rs
@@ -1,6 +1,6 @@
 use ffi;
 
-/// Enum describing the kinds of anchor
+/// Enum describing the kinds of anchors
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AnchorKind {
     Filter,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -19,3 +19,7 @@ ioctl!(readwrite pf_insert_rule with b'D', 27; pfvar::pfioc_rule);
 ioctl!(readwrite pf_change_rule with b'D', 26; pfvar::pfioc_rule);
 // DIOCBEGINADDRS
 ioctl!(readwrite pf_begin_addrs with b'D', 51; pfvar::pfioc_pooladdr);
+// DIOCXBEGIN
+ioctl!(readwrite pf_begin_trans with b'D', 81; pfvar::pfioc_trans);
+// DIOCXCOMMIT
+ioctl!(readwrite pf_commit_trans with b'D', 82; pfvar::pfioc_trans);

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,11 @@ fn run() -> Result<()> {
         err => err.chain_err(|| "Unable to add redirect anchor")?,
     }
 
+    match pf.flush_rules(anchor_name, pfctl::RulesetKind::Filter) {
+        Ok(_) => println!("Flushed filter rules"),
+        err => err.chain_err(|| "Unable to flush filter rules")?,
+    }
+
     let pass_all_rule =
         pfctl::FilterRuleBuilder::default().action(pfctl::RuleAction::Pass).build().unwrap();
     let pass_all4_quick_rule = pfctl::FilterRuleBuilder::default()

--- a/src/ruleset.rs
+++ b/src/ruleset.rs
@@ -1,0 +1,17 @@
+use ffi;
+
+/// Enum describing the kinds of rulesets
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RulesetKind {
+    Filter,
+    Redirect,
+}
+
+impl From<RulesetKind> for i32 {
+    fn from(ruleset_kind: RulesetKind) -> Self {
+        match ruleset_kind {
+            RulesetKind::Filter => ffi::pfvar::PF_RULESET_FILTER as i32,
+            RulesetKind::Redirect => ffi::pfvar::PF_RULESET_RDR as i32,
+        }
+    }
+}


### PR DESCRIPTION
This PR adds capability to remove all rules within anchor. Rules are removed by index, that's why internal loop goes in reverse. 

This loop that removes each rule separately could be built in a way where it removes first rule on each iteration, this would save us a hassle of using `range.rev()`.

The improvement to this PR could be to add transactions (`DIOCXBEGIN`, `DIOCXCOMMIT`). We need to discover though how mentioned above commands work on PF level, whether other changes wait until `DIOCXCOMMIT` or `DIOCXROLLBACK` and what happens if we crashed in between transaction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/13)
<!-- Reviewable:end -->
