### PR TITLE
Add Rust beta to CI build, allow nightly to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@ language: rust
 cache: cargo
 rust:
   - stable
+  - beta
   - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
 os:
   - osx
+
 
 before_script:
   - (cargo install rustfmt || true)


### PR DESCRIPTION
The Rust team recommends that projects test towards beta and nightly even if they only target stable. The reason for this is to catch regression bugs in the compiler and standard libraries. To detect if a change to Rust breaks existing code early.

Since I just upgraded Travis to two parallel builds instead of one, it should be fine to do more builds without it taking longer time.

I also configured it so that the nightly build is allowed to fail. This is also a fairly regular tactic in the Rust world since there are broken nighties now and then and it would suck if all CI builds during that day did not work. With this change it's still possible to see that nightly fail and why, but the corresponding PRs would not be marked as failed any longer if it fails only on nightly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/19)
<!-- Reviewable:end -->
