### PR TITLE
Migrate to bindgen 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ assert_matches = "1.1.0"
 uuid = { version = "0.5", features = ["v4"] }
 
 [build-dependencies]
-bindgen = "0.22"
+bindgen = "0.29"

--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ fn main() {
 
     let _ = bindgen::builder()
         .header("ffi/pfvar.h")
-        .no_unstable_rust()
+        .unstable_rust(false)
         .clang_arg("-DPRIVATE")
         .clang_arg(format!("-I{}/usr/include", sdk_path))
         .clang_arg(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ impl Transaction {
 
     /// Commit transaction
     pub fn commit(&self) -> Result<()> {
-        let mut pfioc_trans_e = unsafe { mem::zeroed::<ffi::pfvar::pfioc_trans_e>() };
+        let mut pfioc_trans_e = unsafe { mem::zeroed::<ffi::pfvar::pfioc_trans_pfioc_trans_e>() };
         self.copy_to(&mut pfioc_trans_e)?;
 
         let mut trans_elements = [pfioc_trans_e];
@@ -294,7 +294,7 @@ impl Transaction {
 
     /// Internal function to obtain transaction ticket
     fn get_ticket(fd: RawFd, anchor: &str, kind: RulesetKind) -> Result<u32> {
-        let mut pfioc_trans_e = unsafe { mem::zeroed::<ffi::pfvar::pfioc_trans_e>() };
+        let mut pfioc_trans_e = unsafe { mem::zeroed::<ffi::pfvar::pfioc_trans_pfioc_trans_e>() };
         Self::setup_trans_element(&anchor, kind, &mut pfioc_trans_e)?;
 
         let mut trans_elements = [pfioc_trans_e];
@@ -308,16 +308,16 @@ impl Transaction {
 
     /// Internal function to wire up pfioc_trans and pfioc_trans_e
     fn setup_trans(pfioc_trans: &mut ffi::pfvar::pfioc_trans,
-                   pfioc_trans_elements: &mut [ffi::pfvar::pfioc_trans_e]) {
+                   pfioc_trans_elements: &mut [ffi::pfvar::pfioc_trans_pfioc_trans_e]) {
         pfioc_trans.size = pfioc_trans_elements.len() as i32;
-        pfioc_trans.esize = mem::size_of::<ffi::pfvar::pfioc_trans_e>() as i32;
+        pfioc_trans.esize = mem::size_of::<ffi::pfvar::pfioc_trans_pfioc_trans_e>() as i32;
         pfioc_trans.array = pfioc_trans_elements.as_mut_ptr();
     }
 
     /// Internal function to initialize pfioc_trans_e
     fn setup_trans_element(anchor: &str,
                            kind: RulesetKind,
-                           pfioc_trans_e: &mut ffi::pfvar::pfioc_trans_e)
+                           pfioc_trans_e: &mut ffi::pfvar::pfioc_trans_pfioc_trans_e)
                            -> Result<()> {
         pfioc_trans_e.rs_num = kind.into();
         anchor
@@ -330,8 +330,8 @@ impl Transaction {
     }
 }
 
-impl TryCopyTo<ffi::pfvar::pfioc_trans_e> for Transaction {
-    fn copy_to(&self, pfioc_trans_e: &mut ffi::pfvar::pfioc_trans_e) -> Result<()> {
+impl TryCopyTo<ffi::pfvar::pfioc_trans_pfioc_trans_e> for Transaction {
+    fn copy_to(&self, pfioc_trans_e: &mut ffi::pfvar::pfioc_trans_pfioc_trans_e) -> Result<()> {
         pfioc_trans_e.ticket = self.ticket;
         Self::setup_trans_element(&self.anchor, self.kind, pfioc_trans_e)
     }


### PR DESCRIPTION
I stumbled upon issues when some of whitelisted `#define` statements weren't picked up by bindgen 0.22 (in upcoming PR), i.e:

```
	u_int8_t		 natpass;

#define PF_STATE_NORMAL		0x1
#define PF_STATE_MODULATE	0x2
#define PF_STATE_SYNPROXY	0x3
	u_int8_t		 keep_state;
	sa_family_t		 af;
```

`PF_STATE_SYNPROXY` was never exported into `pfvar.rs`.

 This PR upgrades bindgen to the latest.

One of most notable changes in bindgen is how inner structs are being handled, consider this:

```
struct pfioc_trans {
	struct pfioc_trans_e {
        	// ...
	} *array;
};
```
New inner struct naming conventions prefix inner structs with the outer structs so `pfioc_trans_e` becomes `pfioc_trans_pfioc_trans_e`. This is ugly, therefore I use a type alias for `pfioc_trans_e` via `build.rs` configuration:
```
pub type pfioc_trans_e = pfioc_trans_pfioc_trans_e
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/21)
<!-- Reviewable:end -->