### PR TITLE
Add logging support for rules

### DIFF
--- a/tests/rules.rs
+++ b/tests/rules.rs
@@ -206,3 +206,21 @@ test!(all_state_policies {
                             "pass inet proto tcp from 192.168.1.4 to any flags any synproxy state"]
     );
 });
+
+test!(logging {
+    let mut pf = pfctl::PfCtl::new().unwrap();
+    let rule = pfctl::FilterRuleBuilder::default()
+        .action(pfctl::RuleAction::Drop)
+        .log(pfctl::RuleLogSet::new(&[
+            pfctl::RuleLog::ExcludeMatchingState,
+            pfctl::RuleLog::IncludeMatchingState,
+            pfctl::RuleLog::SocketOwner,
+        ]))
+        .build()
+        .unwrap();
+    assert_matches!(pf.add_rule(ANCHOR_NAME, &rule), Ok(()));
+    assert_matches!(
+        pfcli::get_rules(ANCHOR_NAME),
+        Ok(ref v) if v == &["block drop log (all, user) all"]
+    );
+});


### PR DESCRIPTION
This PR adds logging support for rules.

Two new types added:

1. `RuleLog` – logging options.
2. `RuleLogSet` – immutable container for `Vec<RuleLog>`. Used to combine `RuleLog` options into bitmask for PF.

Logging flags can be set as following:

```
pfctl::FilterRuleBuilder::default()
  .log(pfctl::RuleLogSet::new(&[
    pfctl::RuleLog::IncludeMatchingState,
    pfctl::RuleLog::SocketOwner,
]))
```

Rules with `log` field set will be visible via `tcpdump` on `pflog` device (run in sudo):

```
ifconfig pflog1 create
tcpdump -n -e -ttt -i pflog1
```

p.s: `tcpdump` has been broken on macOS in early versions of 10.12. Make sure you have at least macOS 10.12.6 if you are planning to test logging capabilities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/23)
<!-- Reviewable:end -->
