### PR TITLE
Add IcmpV6

### DIFF
--- a/src/rule.rs
+++ b/src/rule.rs
@@ -462,6 +462,7 @@ pub enum Proto {
     Tcp,
     Udp,
     Icmp,
+    IcmpV6,
 }
 
 impl Default for Proto {
@@ -477,6 +478,7 @@ impl From<Proto> for u8 {
             Proto::Tcp => libc::IPPROTO_TCP as u8,
             Proto::Udp => libc::IPPROTO_UDP as u8,
             Proto::Icmp => libc::IPPROTO_ICMP as u8,
+            Proto::IcmpV6 => libc::IPPROTO_ICMPV6 as u8,
         }
     }
 }


### PR DESCRIPTION
The reason for adding ICMPv6 is an upcoming PR that adds capabilities to clear firewall states table programmatically. One of tests pings localhost on IPv4 and IPv6 protocols in order to force firewall to create state and verify that we properly map states to requests for clearing them.

It occurred to me that matching against Icmp when using IPv6 does not create a state in firewall. Therefore I concluded that firewall simply couldn't match the combination of protocol and IP version. Switching to IcmpV6 solved that issue and the state was properly created.

This also raises an issue of validating `AddrFamily` and `Proto` in future, so invalid combinations of rules could not be created.

I am not a big expert in the differences between Icmp and Icmpv6 therefore the one could find it obvious that Icmp cannot work IPv6, but not me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/29)
<!-- Reviewable:end -->
