### PR TITLE
Update tests

### DIFF
--- a/tests/rules.rs
+++ b/tests/rules.rs
@@ -8,15 +8,13 @@ extern crate pfctl_test;
 use pfctl_test::pfcli;
 use std::net::Ipv4Addr;
 
-static ANCHOR_NAME: &'static str = "pfctl-rs.integration.testing";
+static ANCHOR_NAME: &'static str = "pfctl-rs.integration.testing.rules";
 
 fn before_each() {
-    let mut pf = pfctl::PfCtl::new().unwrap();
-    match pf.add_anchor(ANCHOR_NAME, pfctl::AnchorKind::Filter) {
-        Ok(_) => (),
-        Err(pfctl::Error(pfctl::ErrorKind::StateAlreadyActive, _)) => (),
-        Err(e) => panic!("Unable to add anchor: {}", e),
-    }
+    pfctl::PfCtl::new()
+        .unwrap()
+        .try_add_anchor(ANCHOR_NAME, pfctl::AnchorKind::Filter)
+        .unwrap();
 }
 
 fn after_each() {


### PR DESCRIPTION
This PR updates rules to use `try_add_anchor` from recent additions to pfctl and restricts flush to rules only in rules tests because the rules tests do not do anything else except adding and removing rules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/30)
<!-- Reviewable:end -->
