### PR TITLE
Add ability to clear states by anchor

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -26,6 +26,8 @@ fn main() {
         .whitelisted_type("pfioc_rule")
         .whitelisted_type("pfioc_pooladdr")
         .whitelisted_type("pfioc_trans")
+        .whitelisted_type("pfioc_states")
+        .whitelisted_type("pfioc_state_kill")
         .whitelisted_var("PF_.*")
         .generate()
         .expect("Unable to generate bindings for pfvar.h")

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -41,12 +41,16 @@ ioctl!(readwrite pf_get_rules with b'D', 6; pfvar::pfioc_rule);
 ioctl!(readwrite pf_get_rule with b'D', 7; pfvar::pfioc_rule);
 // DIOCGETSTATUS
 ioctl!(readwrite pf_get_status with b'D', 21; pfvar::pf_status);
+// DIOCGETSTATES
+ioctl!(readwrite pf_get_states with b'D', 25; pfvar::pfioc_states);
+// DIOCCHANGERULE
+ioctl!(readwrite pf_change_rule with b'D', 26; pfvar::pfioc_rule);
 // DIOCINSERTRULE
 ioctl!(readwrite pf_insert_rule with b'D', 27; pfvar::pfioc_rule);
 // DIOCDELETERULE
 ioctl!(readwrite pf_delete_rule with b'D', 28; pfvar::pfioc_rule);
-// DIOCCHANGERULE
-ioctl!(readwrite pf_change_rule with b'D', 26; pfvar::pfioc_rule);
+// DIOCKILLSTATES
+ioctl!(readwrite pf_kill_states with b'D', 41; pfvar::pfioc_state_kill);
 // DIOCBEGINADDRS
 ioctl!(readwrite pf_begin_addrs with b'D', 51; pfvar::pfioc_pooladdr);
 // DIOCXBEGIN

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -15,7 +15,7 @@ use libc;
 
 use std::fmt;
 use std::mem;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::vec::Vec;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -340,6 +340,27 @@ impl From<Ipv4Addr> for Endpoint {
 impl From<Ipv6Addr> for Endpoint {
     fn from(ip: Ipv6Addr) -> Self {
         Self::from(Ip::from(ip))
+    }
+}
+
+impl From<SocketAddrV4> for Endpoint {
+    fn from(socket_addr: SocketAddrV4) -> Self {
+        Endpoint(Ip::from(*socket_addr.ip()), Port::from(socket_addr.port()))
+    }
+}
+
+impl From<SocketAddrV6> for Endpoint {
+    fn from(socket_addr: SocketAddrV6) -> Self {
+        Endpoint(Ip::from(*socket_addr.ip()), Port::from(socket_addr.port()))
+    }
+}
+
+impl From<SocketAddr> for Endpoint {
+    fn from(socket_addr: SocketAddr) -> Self {
+        match socket_addr {
+            SocketAddr::V4(addr) => Endpoint::from(addr),
+            SocketAddr::V6(addr) => Endpoint::from(addr),
+        }
     }
 }
 

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -343,6 +343,12 @@ impl From<Ipv6Addr> for Endpoint {
     }
 }
 
+impl From<IpAddr> for Endpoint {
+    fn from(ip: IpAddr) -> Self {
+        Self::from(Ip::from(ip))
+    }
+}
+
 impl From<SocketAddrV4> for Endpoint {
     fn from(socket_addr: SocketAddrV4) -> Self {
         Endpoint(Ip::from(*socket_addr.ip()), Port::from(socket_addr.port()))

--- a/tests/states.rs
+++ b/tests/states.rs
@@ -1,0 +1,85 @@
+extern crate pfctl;
+
+#[macro_use]
+extern crate assert_matches;
+
+#[macro_use]
+extern crate pfctl_test;
+use pfctl_test::pfcli;
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
+
+static ANCHOR_NAME: &'static str = "pfctl-rs.integration.testing.states";
+
+fn send_udp_packet(sender: SocketAddr, recepient: SocketAddr) {
+    UdpSocket::bind(sender)
+        .unwrap()
+        .send_to(&[0], recepient)
+        .unwrap();
+}
+
+fn rule_builder(destination: SocketAddr) -> pfctl::FilterRule {
+    pfctl::FilterRuleBuilder::default()
+        .action(pfctl::RuleAction::Pass)
+        .proto(pfctl::Proto::Udp)
+        .to(destination)
+        .quick(true)
+        .keep_state(pfctl::StatePolicy::Keep)
+        .build()
+        .unwrap()
+}
+
+fn before_each() {
+    pfcli::enable_firewall().unwrap();
+    pfctl::PfCtl::new()
+        .unwrap()
+        .try_add_anchor(ANCHOR_NAME, pfctl::AnchorKind::Filter)
+        .unwrap();
+}
+
+fn after_each() {
+    pfcli::flush_rules(ANCHOR_NAME, pfcli::FlushOptions::Rules).unwrap();
+    pfcli::flush_rules(ANCHOR_NAME, pfcli::FlushOptions::States).unwrap();
+}
+
+test!(reset_ipv4_states_by_anchor {
+    let mut pf = pfctl::PfCtl::new().unwrap();
+    let ipv4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    let server_addr = SocketAddr::new(ipv4, 1337);
+    let sender_addr = SocketAddr::new(ipv4, 1338);
+
+    pf.set_rules(ANCHOR_NAME, &[rule_builder(server_addr)]).unwrap();
+    send_udp_packet(sender_addr, server_addr);
+
+    assert_matches!(
+        pfcli::get_states(ANCHOR_NAME),
+        Ok(ref v) if v == &["ALL udp 127.0.0.1:1338 -> 127.0.0.1:1337       SINGLE:NO_TRAFFIC",
+                            "ALL udp 127.0.0.1:1337 <- 127.0.0.1:1338       NO_TRAFFIC:SINGLE"]
+    );
+    assert_matches!(pf.clear_states(ANCHOR_NAME, pfctl::AnchorKind::Filter), Ok(2));
+    assert_matches!(
+        pfcli::get_states(ANCHOR_NAME),
+        Ok(ref v) if v.len() == 0
+    );
+});
+
+test!(reset_ipv6_states_by_anchor {
+    let mut pf = pfctl::PfCtl::new().unwrap();
+    let ipv6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+    let server_addr = SocketAddr::new(ipv6, 1337);
+    let sender_addr = SocketAddr::new(ipv6, 1338);
+
+    pf.set_rules(ANCHOR_NAME, &[rule_builder(server_addr)]).unwrap();
+    send_udp_packet(sender_addr, server_addr);
+
+    assert_matches!(
+        pfcli::get_states(ANCHOR_NAME),
+        Ok(ref v) if v == &["ALL udp ::1[1338] -> ::1[1337]       SINGLE:NO_TRAFFIC",
+                            "ALL udp ::1[1337] <- ::1[1338]       NO_TRAFFIC:SINGLE"]
+    );
+    assert_matches!(pf.clear_states(ANCHOR_NAME, pfctl::AnchorKind::Filter), Ok(2));
+    assert_matches!(
+        pfcli::get_states(ANCHOR_NAME),
+        Ok(ref v) if v.len() == 0
+    );
+});


### PR DESCRIPTION
This PR adds ability to clear states by anchor. The way it is achieved is by finding the anchor index and matching it against all states, then transforming state structure (`pfsync_state`) into state kill request `pfioc_state_kill`. Since `pfsync_state` and `pfioc_state_kill` share a lot of data structures, we mostly copy data 1:1.

Also this PR drops `AsRef<str>`. I don't find it useful and it's barely used and only adds inconvenience of using `as_ref` when values are normally passed as is in existing code base.

The following commits are sent as separate PRs:

- Add IcmpV6 #29 
- Add support for clearing states with pfcli #28 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/31)
<!-- Reviewable:end -->
