### PR TITLE
Add AnchorKind in get_ticket() call

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,7 @@ impl PfCtl {
         let mut pfioc_rule = unsafe { mem::zeroed::<ffi::pfvar::pfioc_rule>() };
 
         pfioc_rule.pool_ticket = get_pool_ticket(self.fd(), anchor)?;
-        pfioc_rule.ticket = self.get_ticket(&anchor)?;
+        pfioc_rule.ticket = self.get_ticket(&anchor, AnchorKind::Filter)?;
         anchor
             .copy_to(&mut pfioc_rule.anchor[..])
             .chain_err(|| ErrorKind::InvalidArgument("Invalid anchor name"))?;
@@ -375,9 +375,10 @@ impl PfCtl {
         Ok(buffer_size / element_size)
     }
 
-    fn get_ticket(&self, anchor: &str) -> Result<u32> {
+    fn get_ticket(&self, anchor: &str, kind: AnchorKind) -> Result<u32> {
         let mut pfioc_rule = unsafe { mem::zeroed::<ffi::pfvar::pfioc_rule>() };
         pfioc_rule.action = ffi::pfvar::PF_CHANGE_GET_TICKET as u32;
+        pfioc_rule.rule.action = kind.into();
         anchor
             .copy_to(&mut pfioc_rule.anchor[..])
             .chain_err(|| ErrorKind::InvalidArgument("Invalid anchor name"))?;


### PR DESCRIPTION
It works fine for `FilterRule` because we zero-fill `pfioc_rule` and `pfioc_rule.rule.action = 0` refers to `PF_PASS`, but does not work for other kinds of rules (such as `RedirectRule`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/36)
<!-- Reviewable:end -->
