### PR TITLE
Rename copy_to to try_copy_to in TryCopyTo trait

### DIFF
--- a/src/rule/endpoint.rs
+++ b/src/rule/endpoint.rs
@@ -75,10 +75,10 @@ impl From<SocketAddr> for Endpoint {
 }
 
 impl TryCopyTo<ffi::pfvar::pf_rule_addr> for Endpoint {
-    fn copy_to(&self, pf_rule_addr: &mut ffi::pfvar::pf_rule_addr) -> Result<()> {
+    fn try_copy_to(&self, pf_rule_addr: &mut ffi::pfvar::pf_rule_addr) -> Result<()> {
         let Endpoint(ref ip, ref port) = *self;
         ip.copy_to(&mut pf_rule_addr.addr);
-        port.copy_to(unsafe { pf_rule_addr.xport.range.as_mut() })?;
+        port.try_copy_to(unsafe { pf_rule_addr.xport.range.as_mut() })?;
         Ok(())
     }
 }

--- a/src/rule/interface.rs
+++ b/src/rule/interface.rs
@@ -28,11 +28,11 @@ impl<T: AsRef<str>> From<T> for Interface {
 }
 
 impl TryCopyTo<[i8]> for Interface {
-    fn copy_to(&self, dst: &mut [i8]) -> Result<()> {
+    fn try_copy_to(&self, dst: &mut [i8]) -> Result<()> {
         match *self {
                 Interface::Any => "",
                 Interface::Name(ref name) => &name[..],
             }
-            .copy_to(dst)
+            .try_copy_to(dst)
     }
 }

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -122,7 +122,7 @@ impl FilterRule {
 }
 
 impl TryCopyTo<ffi::pfvar::pf_rule> for FilterRule {
-    fn copy_to(&self, pf_rule: &mut ffi::pfvar::pf_rule) -> Result<()> {
+    fn try_copy_to(&self, pf_rule: &mut ffi::pfvar::pf_rule) -> Result<()> {
         pf_rule.action = self.action.into();
         pf_rule.direction = self.direction.into();
         pf_rule.quick = self.quick as u8;
@@ -131,12 +131,12 @@ impl TryCopyTo<ffi::pfvar::pf_rule> for FilterRule {
         pf_rule.flags = (&self.tcp_flags.check).into();
         pf_rule.flagset = (&self.tcp_flags.mask).into();
         self.interface
-            .copy_to(&mut pf_rule.ifname)
+            .try_copy_to(&mut pf_rule.ifname)
             .chain_err(|| ErrorKind::InvalidArgument("Incompatible interface name"))?;
         pf_rule.proto = self.proto.into();
         pf_rule.af = self.get_af()?.into();
-        self.from.copy_to(&mut pf_rule.src)?;
-        self.to.copy_to(&mut pf_rule.dst)?;
+        self.from.try_copy_to(&mut pf_rule.src)?;
+        self.to.try_copy_to(&mut pf_rule.dst)?;
         Ok(())
     }
 }
@@ -384,7 +384,7 @@ impl CopyTo<ffi::pfvar::in6_addr> for Ipv6Addr {
 impl<T: AsRef<str>> TryCopyTo<[i8]> for T {
     /// Safely copy a Rust string into a raw buffer. Returning an error if the string could not be
     /// copied to the buffer.
-    fn copy_to(&self, dst: &mut [i8]) -> Result<()> {
+    fn try_copy_to(&self, dst: &mut [i8]) -> Result<()> {
         let src_i8: &[i8] = unsafe { mem::transmute(self.as_ref().as_bytes()) };
 
         ensure!(

--- a/src/rule/port.rs
+++ b/src/rule/port.rs
@@ -31,7 +31,7 @@ impl From<u16> for Port {
 }
 
 impl TryCopyTo<ffi::pfvar::pf_port_range> for Port {
-    fn copy_to(&self, pf_port_range: &mut ffi::pfvar::pf_port_range) -> Result<()> {
+    fn try_copy_to(&self, pf_port_range: &mut ffi::pfvar::pf_port_range) -> Result<()> {
         match *self {
             Port::Any => {
                 pf_port_range.op = ffi::pfvar::PF_OP_NONE as u8;
@@ -60,7 +60,7 @@ impl TryCopyTo<ffi::pfvar::pf_port_range> for Port {
 }
 
 impl TryCopyTo<ffi::pfvar::pf_pool> for Port {
-    fn copy_to(&self, pf_pool: &mut ffi::pfvar::pf_pool) -> Result<()> {
+    fn try_copy_to(&self, pf_pool: &mut ffi::pfvar::pf_pool) -> Result<()> {
         match *self {
             Port::Any => {
                 pf_pool.port_op = ffi::pfvar::PF_OP_NONE as u8;


### PR DESCRIPTION
This PR solves ambiguity issues when both CopyTo and TryCopyTo are implemented for the same type. Even though there is a way to disambiguate with TryCopyTo::copy_to(...) then it becomes obligatory to do the same dance for `CopyTo` calls for the same type as well. 

This PR **attempts** to remedy the described issue by simply renaming the method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/37)
<!-- Reviewable:end -->
