### PR TITLE
Pfcli unify state queries

### DIFF
--- a/tests/anchors.rs
+++ b/tests/anchors.rs
@@ -26,7 +26,7 @@ test!(add_filter_anchor {
 
     assert_matches!(pf.add_anchor(&anchor_name, pfctl::AnchorKind::Filter), Ok(()));
 
-    let anchors = pfcli::get_anchors().unwrap();
+    let anchors = pfcli::get_anchors(None).unwrap();
     assert!(anchors.contains(&anchor_name));
 
     assert_matches!(
@@ -43,7 +43,7 @@ test!(remove_filter_anchor {
     assert_matches!(pf.add_anchor(&anchor_name, pfctl::AnchorKind::Filter), Ok(()));
     assert_matches!(pf.remove_anchor(&anchor_name, pfctl::AnchorKind::Filter), Ok(()));
 
-    let anchors = pfcli::get_anchors().unwrap();
+    let anchors = pfcli::get_anchors(None).unwrap();
     assert!(!anchors.contains(&anchor_name));
 
     assert_matches!(

--- a/tests/states.rs
+++ b/tests/states.rs
@@ -52,13 +52,13 @@ test!(reset_ipv4_states_by_anchor {
     send_udp_packet(sender_addr, server_addr);
 
     assert_matches!(
-        pfcli::get_states(ANCHOR_NAME),
+        pfcli::get_all_states(),
         Ok(ref v) if v == &["ALL udp 127.0.0.1:1338 -> 127.0.0.1:1337       SINGLE:NO_TRAFFIC",
                             "ALL udp 127.0.0.1:1337 <- 127.0.0.1:1338       NO_TRAFFIC:SINGLE"]
     );
     assert_matches!(pf.clear_states(ANCHOR_NAME, pfctl::AnchorKind::Filter), Ok(2));
     assert_matches!(
-        pfcli::get_states(ANCHOR_NAME),
+        pfcli::get_all_states(),
         Ok(ref v) if v.len() == 0
     );
 });
@@ -73,13 +73,13 @@ test!(reset_ipv6_states_by_anchor {
     send_udp_packet(sender_addr, server_addr);
 
     assert_matches!(
-        pfcli::get_states(ANCHOR_NAME),
+        pfcli::get_all_states(),
         Ok(ref v) if v == &["ALL udp ::1[1338] -> ::1[1337]       SINGLE:NO_TRAFFIC",
                             "ALL udp ::1[1337] <- ::1[1338]       NO_TRAFFIC:SINGLE"]
     );
     assert_matches!(pf.clear_states(ANCHOR_NAME, pfctl::AnchorKind::Filter), Ok(2));
     assert_matches!(
-        pfcli::get_states(ANCHOR_NAME),
+        pfcli::get_all_states(),
         Ok(ref v) if v.len() == 0
     );
 });

--- a/tests/states.rs
+++ b/tests/states.rs
@@ -11,6 +11,14 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
 
 static ANCHOR_NAME: &'static str = "pfctl-rs.integration.testing.states";
 
+fn contains_subset(haystack: &Vec<String>, subset: &[&str]) -> bool {
+    subset.iter().all(|&state| haystack.contains(&state.to_owned()))
+}
+
+fn not_contains_subset(haystack: &Vec<String>, subset: &[&str]) -> bool {
+    subset.iter().all(|&state| !haystack.contains(&state.to_owned()))
+}
+
 fn send_udp_packet(sender: SocketAddr, recepient: SocketAddr) {
     UdpSocket::bind(sender)
         .unwrap()
@@ -51,15 +59,19 @@ test!(reset_ipv4_states_by_anchor {
     pf.set_rules(ANCHOR_NAME, &[rule_builder(server_addr)]).unwrap();
     send_udp_packet(sender_addr, server_addr);
 
+    let expected_states = [
+        "ALL udp 127.0.0.1:1338 -> 127.0.0.1:1337       SINGLE:NO_TRAFFIC",
+        "ALL udp 127.0.0.1:1337 <- 127.0.0.1:1338       NO_TRAFFIC:SINGLE"
+    ];
+
     assert_matches!(
         pfcli::get_all_states(),
-        Ok(ref v) if v == &["ALL udp 127.0.0.1:1338 -> 127.0.0.1:1337       SINGLE:NO_TRAFFIC",
-                            "ALL udp 127.0.0.1:1337 <- 127.0.0.1:1338       NO_TRAFFIC:SINGLE"]
+        Ok(ref v) if contains_subset(v, &expected_states)
     );
     assert_matches!(pf.clear_states(ANCHOR_NAME, pfctl::AnchorKind::Filter), Ok(2));
     assert_matches!(
         pfcli::get_all_states(),
-        Ok(ref v) if v.len() == 0
+        Ok(ref v) if not_contains_subset(v, &expected_states)
     );
 });
 
@@ -72,14 +84,18 @@ test!(reset_ipv6_states_by_anchor {
     pf.set_rules(ANCHOR_NAME, &[rule_builder(server_addr)]).unwrap();
     send_udp_packet(sender_addr, server_addr);
 
+    let expected_states = [
+        "ALL udp ::1[1338] -> ::1[1337]       SINGLE:NO_TRAFFIC",
+        "ALL udp ::1[1337] <- ::1[1338]       NO_TRAFFIC:SINGLE"
+    ];
+
     assert_matches!(
         pfcli::get_all_states(),
-        Ok(ref v) if v == &["ALL udp ::1[1338] -> ::1[1337]       SINGLE:NO_TRAFFIC",
-                            "ALL udp ::1[1337] <- ::1[1338]       NO_TRAFFIC:SINGLE"]
+        Ok(ref v) if contains_subset(v, &expected_states)
     );
     assert_matches!(pf.clear_states(ANCHOR_NAME, pfctl::AnchorKind::Filter), Ok(2));
     assert_matches!(
         pfcli::get_all_states(),
-        Ok(ref v) if v.len() == 0
+        Ok(ref v) if not_contains_subset(v, &expected_states)
     );
 });


### PR DESCRIPTION
`get_anchors`, `get_rules` and `get_states` have absolutely the same source code. This PR refactors this and unifies firewall state queries into one function `pfcli::query_state(anchor_name, query_kind)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/38)
<!-- Reviewable:end -->
