### PR TITLE
Update error-chain to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 errno = "0.2"
-error-chain = "0.10"
+error-chain = "0.11"
 ioctl-sys = "0.5.2"
 libc = "0.2.29"
 derive_builder = "0.5"


### PR DESCRIPTION
Lots of small changes. Most notably the motherload of errors it spewed up on nightly are gone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/41)
<!-- Reviewable:end -->
