### PR TITLE
Add travis-ci badge to metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ keywords = ["pf", "pfctl", "firewall", "macos", "network"]
 categories = ["network-programming", "os", "os::unix-apis", "api-bindings", "command-line-utilities"]
 build = "build.rs"
 
+[badges]
+travis-ci = { repository = "mullvad/pfctl-rs" }
+
 [lib]
 path = "src/lib.rs"
 


### PR DESCRIPTION
Just tiny metadata update. Cargo allows specifying CI systems and it will automatically show the build status on crates.io later when we publish it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/42)
<!-- Reviewable:end -->
