### PR TITLE
Add labels support for rules

### DIFF
--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -74,6 +74,8 @@ pub struct FilterRule {
     to: Endpoint,
     #[builder(default)]
     tcp_flags: TcpFlags,
+    #[builder(default)]
+    label: String,
 }
 
 impl FilterRuleBuilder {
@@ -123,8 +125,11 @@ impl TryCopyTo<ffi::pfvar::pf_rule> for FilterRule {
             .chain_err(|| ErrorKind::InvalidArgument("Incompatible interface name"))?;
         pf_rule.proto = self.proto.into();
         pf_rule.af = self.get_af()?.into();
+
         self.from.try_copy_to(&mut pf_rule.src)?;
         self.to.try_copy_to(&mut pf_rule.dst)?;
+        self.label.try_copy_to(&mut pf_rule.label)?;
+
         Ok(())
     }
 }
@@ -149,6 +154,8 @@ pub struct RedirectRule {
     from: Endpoint,
     #[builder(default)]
     to: Endpoint,
+    #[builder(default)]
+    label: String,
     redirect_to: Endpoint,
 }
 
@@ -183,6 +190,7 @@ impl TryCopyTo<ffi::pfvar::pf_rule> for RedirectRule {
 
         self.from.try_copy_to(&mut pf_rule.src)?;
         self.to.try_copy_to(&mut pf_rule.dst)?;
+        self.label.try_copy_to(&mut pf_rule.label)?;
 
         Ok(())
     }


### PR DESCRIPTION
This little fun PR adds support for labels in PF rules.

Usage:

```
FilteRuleBuilder::default().label("😈")
```

PF Output:

```
TRANSLATION RULES:
rdr in inet proto tcp from any to 127.0.0.1 port = 3000 label "👉" -> 127.0.0.1 port 4000

FILTER RULES:
block drop inet from 192.168.1.1 to any
block drop inet from 192.168.2.1 to any port = 80 label "👮‍♀️🚨🚓"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/43)
<!-- Reviewable:end -->
