### PR TITLE
Mark to_palist as unsafe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,7 @@ impl PfCtl {
 
         // copy address pool in pf_rule
         let redirect_pool = redirect_to.ip().to_pool_addr_list();
-        pfioc_rule.rule.rpool.list = redirect_pool.to_palist();
+        pfioc_rule.rule.rpool.list = unsafe { redirect_pool.to_palist() };
         redirect_to.port().try_copy_to(&mut pfioc_rule.rule.rpool)?;
 
         // set tickets

--- a/src/pooladdr.rs
+++ b/src/pooladdr.rs
@@ -42,7 +42,7 @@ impl PoolAddrList {
 
     /// Returns a copy of inner pf_palist linked list.
     /// Returned copy should never be used past the lifetime expiration of PoolAddrList.
-    pub fn to_palist(&self) -> ffi::pfvar::pf_palist {
+    pub unsafe fn to_palist(self) -> ffi::pfvar::pf_palist {
         self.list
     }
 


### PR DESCRIPTION
This method returns data that is highly unsafe to use unless the coder knows what she is doing. So I mark it as unsafe at least so one has to call it within `unsafe {}`. This should make it more clear at the point of usage that one has to be careful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/44)
<!-- Reviewable:end -->
