### PR TITLE
Advanced Transactions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,8 @@ mod ruleset;
 pub use ruleset::*;
 
 mod transaction;
-use transaction::*;
+pub use transaction::AnchorChange;
+use transaction::Transaction;
 
 mod errors {
     error_chain! {
@@ -251,9 +252,9 @@ impl PfCtl {
         ioctl_guard!(ffi::pf_change_rule(self.fd(), &mut pfioc_rule))
     }
 
-    pub fn set_rules(&mut self, anchor: &str, rules: &[FilterRule]) -> Result<()> {
-        let trans = Transaction::new(&anchor, RulesetKind::Filter)?;
-        trans.add_rules(rules)?;
+    pub fn set_rules(&mut self, ruleset_change: AnchorChange) -> Result<()> {
+        let mut trans = Transaction::new()?;
+        trans.add_change(ruleset_change);
         trans.commit()
     }
 
@@ -285,7 +286,14 @@ impl PfCtl {
     }
 
     pub fn flush_rules(&mut self, anchor: &str, kind: RulesetKind) -> Result<()> {
-        Transaction::new(&anchor, kind)?.commit()
+        let mut trans = Transaction::new()?;
+        let mut anchor_change = AnchorChange::new(anchor);
+        match kind {
+            RulesetKind::Filter => anchor_change.set_filter_rules(Vec::new()),
+            RulesetKind::Redirect => anchor_change.set_redirect_rules(Vec::new()),
+        };
+        trans.add_change(anchor_change);
+        trans.commit()
     }
 
     /// Clear states created by rules in anchor.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,9 +252,9 @@ impl PfCtl {
         ioctl_guard!(ffi::pf_change_rule(self.fd(), &mut pfioc_rule))
     }
 
-    pub fn set_rules(&mut self, ruleset_change: AnchorChange) -> Result<()> {
+    pub fn set_rules(&mut self, anchor_changes: Vec<AnchorChange>) -> Result<()> {
         let mut trans = Transaction::new()?;
-        trans.add_change(ruleset_change);
+        trans.add_changes(anchor_changes);
         trans.commit()
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,27 +86,6 @@ fn run() -> Result<()> {
         .unwrap();
     pf.add_rule(anchor_name, &to_port_rule).chain_err(|| "Unable to add port rule")?;
 
-    let ipv6 = Ipv6Addr::new(0xbeef, 8, 7, 6, 5, 4, 3, 2);
-    let from_ipv6_rule = pfctl::FilterRuleBuilder::default()
-        .action(pfctl::FilterRuleAction::Pass)
-        .from(ipv6)
-        .build()
-        .unwrap();
-    pf.add_rule(anchor_name, &from_ipv6_rule).chain_err(|| "Unable to add IPv6 rule")?;
-
-    let trans_rule1 = pfctl::FilterRuleBuilder::default()
-        .action(pfctl::FilterRuleAction::Drop)
-        .from(Ipv4Addr::new(192, 168, 1, 1))
-        .build()
-        .unwrap();
-    let trans_rule2 = pfctl::FilterRuleBuilder::default()
-        .action(pfctl::FilterRuleAction::Drop)
-        .from(Ipv4Addr::new(192, 168, 2, 1))
-        .to(pfctl::Port::from(80))
-        .build()
-        .unwrap();
-    pf.set_rules(anchor_name, &[trans_rule1, trans_rule2]).chain_err(|| "Unable to set rules")?;
-
     let mut rdr_rule_builder = pfctl::RedirectRuleBuilder::default();
     let rdr_rule1 = rdr_rule_builder
         .action(pfctl::RedirectRuleAction::Redirect)
@@ -129,6 +108,37 @@ fn run() -> Result<()> {
         .unwrap();
 
     pf.add_redirect_rule(anchor_name, &rdr_rule1).chain_err(|| "Unable to add rdr rule")?;
+
+    let ipv6 = Ipv6Addr::new(0xbeef, 8, 7, 6, 5, 4, 3, 2);
+    let from_ipv6_rule = pfctl::FilterRuleBuilder::default()
+        .action(pfctl::FilterRuleAction::Pass)
+        .from(ipv6)
+        .build()
+        .unwrap();
+    pf.add_rule(anchor_name, &from_ipv6_rule).chain_err(|| "Unable to add IPv6 rule")?;
+
+    let trans_rule1 = pfctl::FilterRuleBuilder::default()
+        .action(pfctl::FilterRuleAction::Drop)
+        .from(Ipv4Addr::new(192, 168, 1, 1))
+        .build()
+        .unwrap();
+    let trans_rule2 = pfctl::FilterRuleBuilder::default()
+        .action(pfctl::FilterRuleAction::Drop)
+        .from(Ipv4Addr::new(192, 168, 2, 1))
+        .to(pfctl::Port::from(80))
+        .build()
+        .unwrap();
+    let trans_rule3 = pfctl::RedirectRuleBuilder::default()
+        .action(pfctl::RedirectRuleAction::Redirect)
+        .to(pfctl::Port::from(80))
+        .redirect_to(pfctl::Port::from(8080))
+        .build()
+        .unwrap();
+    let mut trans_change = pfctl::AnchorChange::new("anchor_name");
+    trans_change.filter_rules = Some(vec![trans_rule1, trans_rule2]);
+    trans_change.redirect_rules = Some(vec![trans_rule3]);
+    pf.set_rules(trans_change)
+        .chain_err(|| "Unable to set rules")?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,8 @@ mod errors {
 }
 use errors::*;
 
+static ANCHOR_NAME: &str = "test.anchor";
+
 quick_main!(run);
 
 fn run() -> Result<()> {
@@ -36,19 +38,17 @@ fn run() -> Result<()> {
         err => err.chain_err(|| "Unable to enable PF")?,
     }
 
-    let anchor_name = "test.anchor";
-
-    pf.try_add_anchor(anchor_name, pfctl::AnchorKind::Filter)
+    pf.try_add_anchor(ANCHOR_NAME, pfctl::AnchorKind::Filter)
         .chain_err(|| "Unable to add filter anchor")?;
-    pf.try_add_anchor(anchor_name, pfctl::AnchorKind::Redirect)
+    pf.try_add_anchor(ANCHOR_NAME, pfctl::AnchorKind::Redirect)
         .chain_err(|| "Unable to add redirect anchor")?;
 
-    match pf.flush_rules(anchor_name, pfctl::RulesetKind::Filter) {
+    match pf.flush_rules(ANCHOR_NAME, pfctl::RulesetKind::Filter) {
         Ok(_) => println!("Flushed filter rules"),
         err => err.chain_err(|| "Unable to flush filter rules")?,
     }
 
-    match pf.flush_rules(anchor_name, pfctl::RulesetKind::Redirect) {
+    match pf.flush_rules(ANCHOR_NAME, pfctl::RulesetKind::Redirect) {
         Ok(_) => println!("Flushed rdr rules"),
         err => err.chain_err(|| "Unable to flush rdr rules")?,
     }
@@ -67,9 +67,9 @@ fn run() -> Result<()> {
         .interface("utun0")
         .build()
         .unwrap();
-    pf.add_rule(anchor_name, &pass_all_rule).chain_err(|| "Unable to add rule")?;
-    pf.add_rule(anchor_name, &pass_all4_quick_rule).chain_err(|| "Unable to add rule")?;
-    pf.add_rule(anchor_name, &pass_all6_rule).chain_err(|| "Unable to add rule")?;
+    pf.add_rule(ANCHOR_NAME, &pass_all_rule).chain_err(|| "Unable to add rule")?;
+    pf.add_rule(ANCHOR_NAME, &pass_all4_quick_rule).chain_err(|| "Unable to add rule")?;
+    pf.add_rule(ANCHOR_NAME, &pass_all6_rule).chain_err(|| "Unable to add rule")?;
 
     let from_net = IpNetwork::from_str("192.168.99.11/24").unwrap();
     let from_net_rule = pfctl::FilterRuleBuilder::default()
@@ -77,14 +77,14 @@ fn run() -> Result<()> {
         .from(pfctl::Ip::from(from_net))
         .build()
         .unwrap();
-    pf.add_rule(anchor_name, &from_net_rule).chain_err(|| "Unable to add IPv4 net rule")?;
+    pf.add_rule(ANCHOR_NAME, &from_net_rule).chain_err(|| "Unable to add IPv4 net rule")?;
 
     let to_port_rule = pfctl::FilterRuleBuilder::default()
         .action(pfctl::FilterRuleAction::Pass)
         .to(pfctl::Port::from(9876))
         .build()
         .unwrap();
-    pf.add_rule(anchor_name, &to_port_rule).chain_err(|| "Unable to add port rule")?;
+    pf.add_rule(ANCHOR_NAME, &to_port_rule).chain_err(|| "Unable to add port rule")?;
 
     let mut rdr_rule_builder = pfctl::RedirectRuleBuilder::default();
     let rdr_rule1 = rdr_rule_builder
@@ -107,7 +107,7 @@ fn run() -> Result<()> {
         .build()
         .unwrap();
 
-    pf.add_redirect_rule(anchor_name, &rdr_rule1).chain_err(|| "Unable to add rdr rule")?;
+    pf.add_redirect_rule(ANCHOR_NAME, &rdr_rule1).chain_err(|| "Unable to add rdr rule")?;
 
     let ipv6 = Ipv6Addr::new(0xbeef, 8, 7, 6, 5, 4, 3, 2);
     let from_ipv6_rule = pfctl::FilterRuleBuilder::default()
@@ -115,29 +115,29 @@ fn run() -> Result<()> {
         .from(ipv6)
         .build()
         .unwrap();
-    pf.add_rule(anchor_name, &from_ipv6_rule).chain_err(|| "Unable to add IPv6 rule")?;
+    pf.add_rule(ANCHOR_NAME, &from_ipv6_rule).chain_err(|| "Unable to add IPv6 rule")?;
 
     let trans_rule1 = pfctl::FilterRuleBuilder::default()
         .action(pfctl::FilterRuleAction::Drop)
-        .from(Ipv4Addr::new(192, 168, 1, 1))
+        .from(Ipv4Addr::new(192, 168, 234, 1))
         .build()
         .unwrap();
     let trans_rule2 = pfctl::FilterRuleBuilder::default()
         .action(pfctl::FilterRuleAction::Drop)
-        .from(Ipv4Addr::new(192, 168, 2, 1))
+        .from(Ipv4Addr::new(192, 168, 234, 2))
         .to(pfctl::Port::from(80))
         .build()
         .unwrap();
     let trans_rule3 = pfctl::RedirectRuleBuilder::default()
         .action(pfctl::RedirectRuleAction::Redirect)
-        .to(pfctl::Port::from(80))
-        .redirect_to(pfctl::Port::from(8080))
+        .to(pfctl::Port::from(1337))
+        .redirect_to(pfctl::Port::from(1338))
         .build()
         .unwrap();
-    let mut trans_change = pfctl::AnchorChange::new("anchor_name");
-    trans_change.filter_rules = Some(vec![trans_rule1, trans_rule2]);
-    trans_change.redirect_rules = Some(vec![trans_rule3]);
-    pf.set_rules(trans_change)
+    let mut trans_change = pfctl::AnchorChange::new(ANCHOR_NAME);
+    trans_change.set_filter_rules(vec![trans_rule1, trans_rule2]);
+    trans_change.set_redirect_rules(vec![trans_rule3]);
+    pf.set_rules(vec![trans_change])
         .chain_err(|| "Unable to set rules")?;
 
     Ok(())

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -7,8 +7,8 @@
 // except according to those terms.
 
 use {ErrorKind, Result, ResultExt};
-use {FilterRule, RulesetKind};
-use conversion::TryCopyTo;
+use {FilterRule, RedirectRule, RulesetKind};
+use conversion::{CopyTo, TryCopyTo};
 use ffi;
 
 use std::fs::File;
@@ -16,73 +16,65 @@ use std::mem;
 use std::os::unix::io::{AsRawFd, RawFd};
 use utils;
 
+/// Structure that allows to manipulate rules in batches
 #[derive(Debug)]
 pub struct Transaction {
     file: File,
-    ticket: u32,
-    kind: RulesetKind,
-    anchor: String,
+    anchor_changes: Vec<AnchorChange>,
 }
 
 impl Transaction {
     /// Returns a new `Transaction` if opening the PF device file succeeded.
-    pub fn new(anchor: &str, kind: RulesetKind) -> Result<Self> {
-        let file = utils::open_pf()?;
-        let ticket = Self::get_ticket(file.as_raw_fd(), &anchor, kind)?;
+    pub fn new() -> Result<Self> {
         Ok(
             Transaction {
-                file: file,
-                ticket: ticket,
-                kind: kind,
-                anchor: anchor.to_owned(),
+                file: utils::open_pf()?,
+                anchor_changes: Vec::new(),
             },
         )
     }
 
+    /// Add change into transaction replacing the prior change registered for corresponding anchor
+    /// if any.
+    pub fn add_change(&mut self, anchor_change: AnchorChange) {
+        if let Some(index) =
+            self.anchor_changes.iter().position(|r| r.anchor == anchor_change.anchor) {
+            self.anchor_changes.push(anchor_change);
+            self.anchor_changes.swap_remove(index);
+        } else {
+            self.anchor_changes.push(anchor_change);
+        }
+    }
+
     /// Commit transaction
     pub fn commit(&self) -> Result<()> {
-        let mut pfioc_trans_e = unsafe { mem::zeroed::<ffi::pfvar::pfioc_trans_pfioc_trans_e>() };
-        self.try_copy_to(&mut pfioc_trans_e)?;
-
-        let mut trans_elements = [pfioc_trans_e];
         let mut pfioc_trans = unsafe { mem::zeroed::<ffi::pfvar::pfioc_trans>() };
-        Self::setup_trans(&mut pfioc_trans, &mut trans_elements);
+        let mut pfioc_trans_elements = self.get_all_trans_elements()?;
+        Self::setup_trans(&mut pfioc_trans, pfioc_trans_elements.as_mut_slice());
 
-        ioctl_guard!(ffi::pf_commit_trans(self.fd(), &mut pfioc_trans))
-    }
+        // fill in array of pfioc_trans_e with tickets
+        ioctl_guard!(ffi::pf_begin_trans(self.fd(), &mut pfioc_trans))?;
 
-    /// Append an array of rules into transaction
-    pub fn add_rules(&self, rules: &[FilterRule]) -> Result<()> {
-        for rule in rules.iter() {
-            self.add_rule(&rule)?;
+        let mut ticket_iterator = pfioc_trans_elements.iter().map(|e| e.ticket);
+        for anchor_change in self.anchor_changes.iter() {
+            if let Some(ref filter_rules) = anchor_change.filter_rules {
+                self.add_filter_rules(
+                        &anchor_change.anchor,
+                        filter_rules,
+                        ticket_iterator.next().unwrap(),
+                    )?;
+            }
+            if let Some(ref redirect_rules) = anchor_change.redirect_rules {
+                self.add_redirect_rules(
+                        &anchor_change.anchor,
+                        redirect_rules,
+                        ticket_iterator.next().unwrap(),
+                    )?;
+            }
         }
-        Ok(())
-    }
 
-    /// Append single rule into transaction
-    pub fn add_rule(&self, rule: &FilterRule) -> Result<()> {
-        let mut pfioc_rule = unsafe { mem::zeroed::<ffi::pfvar::pfioc_rule>() };
-
-        pfioc_rule.action = ffi::pfvar::PF_CHANGE_NONE as u32;
-        pfioc_rule.pool_ticket = utils::get_pool_ticket(self.fd(), &self.anchor)?;
-        rule.try_copy_to(&mut pfioc_rule.rule)?;
-        self.try_copy_to(&mut pfioc_rule)?;
-
-        ioctl_guard!(ffi::pf_add_rule(self.fd(), &mut pfioc_rule))
-    }
-
-    /// Internal function to obtain transaction ticket
-    fn get_ticket(fd: RawFd, anchor: &str, kind: RulesetKind) -> Result<u32> {
-        let mut pfioc_trans_e = unsafe { mem::zeroed::<ffi::pfvar::pfioc_trans_pfioc_trans_e>() };
-        Self::setup_trans_element(&anchor, kind, &mut pfioc_trans_e)?;
-
-        let mut trans_elements = [pfioc_trans_e];
-        let mut pfioc_trans = unsafe { mem::zeroed::<ffi::pfvar::pfioc_trans>() };
-        Self::setup_trans(&mut pfioc_trans, &mut trans_elements);
-
-        ioctl_guard!(ffi::pf_begin_trans(fd, &mut pfioc_trans))?;
-
-        Ok(trans_elements[0].ticket)
+        // commit transaction
+        ioctl_guard!(ffi::pf_commit_trans(self.fd(), &mut pfioc_trans))
     }
 
     /// Internal function to wire up pfioc_trans and pfioc_trans_e
@@ -94,14 +86,119 @@ impl Transaction {
     }
 
     /// Internal function to initialize pfioc_trans_e
-    fn setup_trans_element(anchor: &str,
-                           kind: RulesetKind,
-                           pfioc_trans_e: &mut ffi::pfvar::pfioc_trans_pfioc_trans_e)
-                           -> Result<()> {
-        pfioc_trans_e.rs_num = kind.into();
+    fn new_trans_element(anchor: &str,
+                         ruleset_kind: RulesetKind)
+                         -> Result<ffi::pfvar::pfioc_trans_pfioc_trans_e> {
+        let mut pfioc_trans_e = unsafe { mem::zeroed::<ffi::pfvar::pfioc_trans_pfioc_trans_e>() };
+        pfioc_trans_e.rs_num = ruleset_kind.into();
         anchor
             .try_copy_to(&mut pfioc_trans_e.anchor[..])
-            .chain_err(|| ErrorKind::InvalidArgument("Invalid anchor name"))
+            .chain_err(|| ErrorKind::InvalidArgument("Invalid anchor name"))?;
+        Ok(pfioc_trans_e)
+    }
+
+    /// Internal function to produce a flat list of transaction elements (pfioc_trans_e) for each
+    /// anchor.
+    fn get_all_trans_elements(&self) -> Result<Vec<ffi::pfvar::pfioc_trans_pfioc_trans_e>> {
+        // make transaction elements (pfioc_trans_e) for each anchor
+        let trans_elements_by_anchor = self.anchor_changes
+            .iter()
+            .map(Self::get_trans_elements)
+            .collect::<Result<Vec<_>>>()?;
+        // flatten Vec<Vec<pfioc_trans_e>>
+        Ok(
+            trans_elements_by_anchor
+                .into_iter()
+                .flat_map(|e| e.into_iter())
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Internal function to produces an array of pfioc_trans_e for each kind of rules skipping
+    /// ones with None set in the following order: filter, redirect.
+    fn get_trans_elements(anchor_change: &AnchorChange)
+                          -> Result<Vec<ffi::pfvar::pfioc_trans_pfioc_trans_e>> {
+        let mut trans_elements = Vec::new();
+        if anchor_change.filter_rules.is_some() {
+            trans_elements.push(
+                Self::new_trans_element(
+                    &anchor_change.anchor,
+                    RulesetKind::Filter
+                )?
+            );
+        }
+        if anchor_change.redirect_rules.is_some() {
+            trans_elements.push(
+                Self::new_trans_element(
+                    &anchor_change.anchor,
+                    RulesetKind::Redirect,
+                )?,
+            );
+        }
+        Ok(trans_elements)
+    }
+
+    /// Internal function add single filter rule into transaction
+    fn add_filter_rule(&self, anchor: &str, rule: &FilterRule, ticket: u32) -> Result<()> {
+        // fill in rule information
+        let mut pfioc_rule = unsafe { mem::zeroed::<ffi::pfvar::pfioc_rule>() };
+        pfioc_rule.action = ffi::pfvar::PF_CHANGE_NONE as u32;
+        pfioc_rule.pool_ticket = utils::get_pool_ticket(self.fd(), &anchor)?;
+        rule.try_copy_to(&mut pfioc_rule.rule)?;
+
+        // fill in ticket with ticket associated with transaction
+        pfioc_rule.ticket = ticket;
+        anchor
+            .try_copy_to(&mut pfioc_rule.anchor[..])
+            .chain_err(|| ErrorKind::InvalidArgument("Invalid anchor name"))?;
+
+        // add rule into transaction
+        ioctl_guard!(ffi::pf_add_rule(self.fd(), &mut pfioc_rule))
+            .chain_err(|| "pf_add_rule failed")
+    }
+
+    /// Internal function to add batch of filter rules into transaction
+    fn add_filter_rules(&self, anchor: &str, rules: &[FilterRule], ticket: u32) -> Result<()> {
+        for rule in rules {
+            self.add_filter_rule(anchor, rule, ticket)?;
+        }
+        Ok(())
+    }
+
+    /// Internal function to add single redirect rule into transaction
+    fn add_redirect_rule(&self, anchor: &str, rule: &RedirectRule, ticket: u32) -> Result<()> {
+        // register redirect address in newly created address pool
+        let redirect_to = rule.get_redirect_to();
+        let mut pfioc_pooladdr = unsafe { mem::zeroed::<ffi::pfvar::pfioc_pooladdr>() };
+        ioctl_guard!(ffi::pf_begin_addrs(self.fd(), &mut pfioc_pooladdr))?;
+        redirect_to.ip().copy_to(&mut pfioc_pooladdr.addr.addr);
+        ioctl_guard!(ffi::pf_add_addr(self.fd(), &mut pfioc_pooladdr))?;
+
+        // prepare pfioc_rule
+        let mut pfioc_rule = unsafe { mem::zeroed::<ffi::pfvar::pfioc_rule>() };
+        anchor.try_copy_to(&mut pfioc_rule.anchor[..])?;
+        rule.try_copy_to(&mut pfioc_rule.rule)?;
+
+        // copy address pool in pf_rule
+        let redirect_pool = redirect_to.ip().to_pool_addr_list();
+        pfioc_rule.rule.rpool.list = unsafe { redirect_pool.to_palist() };
+        redirect_to.port().try_copy_to(&mut pfioc_rule.rule.rpool)?;
+
+        // set tickets
+        pfioc_rule.pool_ticket = pfioc_pooladdr.ticket;
+        pfioc_rule.ticket = ticket;
+
+        // add rule into transaction
+        ioctl_guard!(ffi::pf_add_rule(self.fd(), &mut pfioc_rule))
+            .chain_err(|| "pf_add_rule failed")
+    }
+
+    /// Internal function to add batch of redirect rules into transaction
+    fn add_redirect_rules(&self, anchor: &str, rules: &[RedirectRule], ticket: u32) -> Result<()> {
+        for rule in rules {
+            self.add_redirect_rule(anchor, rule, ticket)?;
+        }
+        Ok(())
     }
 
     fn fd(&self) -> RawFd {
@@ -109,18 +206,32 @@ impl Transaction {
     }
 }
 
-impl TryCopyTo<ffi::pfvar::pfioc_trans_pfioc_trans_e> for Transaction {
-    fn try_copy_to(&self, pfioc_trans_e: &mut ffi::pfvar::pfioc_trans_pfioc_trans_e) -> Result<()> {
-        pfioc_trans_e.ticket = self.ticket;
-        Self::setup_trans_element(&self.anchor, self.kind, pfioc_trans_e)
-    }
+
+/// Structure that describes anchor rules manipulation allowing for targeted changes in anchors.
+/// Rules that are set to Some() will replace corresponding ruleset in anchor, while
+/// rules that set to None will remain untouched during transaction.
+#[derive(Debug)]
+pub struct AnchorChange {
+    pub anchor: String,
+    pub filter_rules: Option<Vec<FilterRule>>,
+    pub redirect_rules: Option<Vec<RedirectRule>>,
 }
 
-impl TryCopyTo<ffi::pfvar::pfioc_rule> for Transaction {
-    fn try_copy_to(&self, pfioc_rule: &mut ffi::pfvar::pfioc_rule) -> Result<()> {
-        pfioc_rule.ticket = self.ticket;
-        self.anchor
-            .try_copy_to(&mut pfioc_rule.anchor[..])
-            .chain_err(|| ErrorKind::InvalidArgument("Invalid anchor name"))
+impl AnchorChange {
+    /// Returns an empty changeset for corresponding anchor
+    pub fn new(anchor: &str) -> Self {
+        AnchorChange {
+            anchor: anchor.to_owned(),
+            filter_rules: None,
+            redirect_rules: None,
+        }
+    }
+
+    pub fn set_filter_rules(&mut self, rules: Vec<FilterRule>) {
+        self.filter_rules = Some(rules);
+    }
+
+    pub fn set_redirect_rules(&mut self, rules: Vec<RedirectRule>) {
+        self.redirect_rules = Some(rules);
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -46,32 +46,49 @@ impl Transaction {
         }
     }
 
+    /// Convenience method to add multiple changes into Transaction.
+    pub fn add_changes(&mut self, anchor_changes: Vec<AnchorChange>) {
+        for anchor_change in anchor_changes {
+            self.add_change(anchor_change);
+        }
+    }
+
     /// Commit transaction
     pub fn commit(&self) -> Result<()> {
         let mut pfioc_trans = unsafe { mem::zeroed::<ffi::pfvar::pfioc_trans>() };
-        let mut pfioc_trans_elements = self.get_all_trans_elements()?;
-        Self::setup_trans(&mut pfioc_trans, pfioc_trans_elements.as_mut_slice());
+        let mut trans_elements = self.get_trans_elements()?;
+        Self::setup_trans(&mut pfioc_trans, trans_elements.get_mut_heap());
 
         // fill in array of pfioc_trans_e with tickets
         ioctl_guard!(ffi::pf_begin_trans(self.fd(), &mut pfioc_trans))?;
 
-        let mut ticket_iterator = pfioc_trans_elements.iter().map(|e| e.ticket);
-        for anchor_change in self.anchor_changes.iter() {
-            if let Some(ref filter_rules) = anchor_change.filter_rules {
-                self.add_filter_rules(
+        // register all rules in this transaction with firewall
+        trans_elements
+            .get_filter_elements()
+            .into_iter()
+            .map(
+                |(anchor_change, pfioc_trans_e)| {
+                    self.add_filter_rules(
                         &anchor_change.anchor,
-                        filter_rules,
-                        ticket_iterator.next().unwrap(),
-                    )?;
-            }
-            if let Some(ref redirect_rules) = anchor_change.redirect_rules {
-                self.add_redirect_rules(
+                        anchor_change.filter_rules.as_ref().unwrap(),
+                        pfioc_trans_e.ticket,
+                    )
+                },
+            )
+            .collect::<Result<Vec<_>>>()?;
+        trans_elements
+            .get_redirect_elements()
+            .into_iter()
+            .map(
+                |(anchor_change, pfioc_trans_e)| {
+                    self.add_redirect_rules(
                         &anchor_change.anchor,
-                        redirect_rules,
-                        ticket_iterator.next().unwrap(),
-                    )?;
-            }
-        }
+                        anchor_change.redirect_rules.as_ref().unwrap(),
+                        pfioc_trans_e.ticket,
+                    )
+                },
+            )
+            .collect::<Result<Vec<_>>>()?;
 
         // commit transaction
         ioctl_guard!(ffi::pf_commit_trans(self.fd(), &mut pfioc_trans))
@@ -85,57 +102,14 @@ impl Transaction {
         pfioc_trans.array = pfioc_trans_elements.as_mut_ptr();
     }
 
-    /// Internal function to initialize pfioc_trans_e
-    fn new_trans_element(anchor: &str,
-                         ruleset_kind: RulesetKind)
-                         -> Result<ffi::pfvar::pfioc_trans_pfioc_trans_e> {
-        let mut pfioc_trans_e = unsafe { mem::zeroed::<ffi::pfvar::pfioc_trans_pfioc_trans_e>() };
-        pfioc_trans_e.rs_num = ruleset_kind.into();
-        anchor
-            .try_copy_to(&mut pfioc_trans_e.anchor[..])
-            .chain_err(|| ErrorKind::InvalidArgument("Invalid anchor name"))?;
-        Ok(pfioc_trans_e)
-    }
-
-    /// Internal function to produce a flat list of transaction elements (pfioc_trans_e) for each
-    /// anchor.
-    fn get_all_trans_elements(&self) -> Result<Vec<ffi::pfvar::pfioc_trans_pfioc_trans_e>> {
-        // make transaction elements (pfioc_trans_e) for each anchor
-        let trans_elements_by_anchor = self.anchor_changes
+    /// Internal function to produce transaction elements store for each kind of rule
+    fn get_trans_elements(&self) -> Result<TransactionElements> {
+        let mut trans_elements = TransactionElements::new();
+        self.anchor_changes
             .iter()
-            .map(Self::get_trans_elements)
-            .collect::<Result<Vec<_>>>()?;
-        // flatten Vec<Vec<pfioc_trans_e>>
-        Ok(
-            trans_elements_by_anchor
-                .into_iter()
-                .flat_map(|e| e.into_iter())
-                .collect::<Vec<_>>(),
-        )
-    }
-
-    /// Internal function to produces an array of pfioc_trans_e for each kind of rules skipping
-    /// ones with None set in the following order: filter, redirect.
-    fn get_trans_elements(anchor_change: &AnchorChange)
-                          -> Result<Vec<ffi::pfvar::pfioc_trans_pfioc_trans_e>> {
-        let mut trans_elements = Vec::new();
-        if anchor_change.filter_rules.is_some() {
-            trans_elements.push(
-                Self::new_trans_element(
-                    &anchor_change.anchor,
-                    RulesetKind::Filter
-                )?
-            );
-        }
-        if anchor_change.redirect_rules.is_some() {
-            trans_elements.push(
-                Self::new_trans_element(
-                    &anchor_change.anchor,
-                    RulesetKind::Redirect,
-                )?,
-            );
-        }
-        Ok(trans_elements)
+            .map(|anchor_change| trans_elements.add_elements(anchor_change))
+            .collect::<Result<Vec<_>>>()
+            .map(|_| trans_elements)
     }
 
     /// Internal function add single filter rule into transaction
@@ -235,3 +209,93 @@ impl AnchorChange {
         self.redirect_rules = Some(rules);
     }
 }
+
+
+mod private {
+    use super::*;
+
+    pub struct TransactionElements<'a> {
+        heap: Vec<ffi::pfvar::pfioc_trans_pfioc_trans_e>,
+        filter_indices: Vec<(&'a AnchorChange, usize)>,
+        redirect_indices: Vec<(&'a AnchorChange, usize)>,
+    }
+
+    impl<'a> TransactionElements<'a> {
+        /// Initializes empty TransactionElements holder
+        pub fn new() -> Self {
+            TransactionElements {
+                heap: Vec::new(),
+                filter_indices: Vec::new(),
+                redirect_indices: Vec::new(),
+            }
+        }
+
+        /// Returns mutable slice from inner vector that contains all transaction elements
+        pub fn get_mut_heap(&mut self) -> &mut [ffi::pfvar::pfioc_trans_pfioc_trans_e] {
+            self.heap.as_mut_slice()
+        }
+
+        /// Registers transaction elements for each ruleset in AnchorChange
+        pub fn add_elements(&mut self, anchor_change: &'a AnchorChange) -> Result<()> {
+            if anchor_change.filter_rules.is_some() {
+                self.add_filter_element(&anchor_change)?;
+            }
+            if anchor_change.redirect_rules.is_some() {
+                self.add_redirect_element(&anchor_change)?;
+            }
+            Ok(())
+        }
+
+        /// Returns series of tuples with corresponding AnchorChange and transaction elements
+        /// (pfioc_trans_e) with tickets obtained for filter rules update
+        pub fn get_filter_elements
+            (&'a self)
+             -> Vec<(&'a AnchorChange, &'a ffi::pfvar::pfioc_trans_pfioc_trans_e)> {
+            self.filter_indices
+                .iter()
+                .map(|&(a, i)| (a, &self.heap[i]))
+                .collect::<Vec<(&AnchorChange, &ffi::pfvar::pfioc_trans_pfioc_trans_e)>>()
+        }
+
+        /// Returns series of tuples with corresponding AnchorChange and transaction elements
+        /// (pfioc_trans_e) with tickets obtained for redirect rules update
+        pub fn get_redirect_elements
+            (&'a self)
+             -> Vec<(&'a AnchorChange, &'a ffi::pfvar::pfioc_trans_pfioc_trans_e)> {
+            self.redirect_indices
+                .iter()
+                .map(|&(a, i)| (a, &self.heap[i]))
+                .collect::<Vec<(&AnchorChange, &ffi::pfvar::pfioc_trans_pfioc_trans_e)>>()
+        }
+
+        /// Internal function to register filter element for corresponding AnchorChange
+        fn add_filter_element(&mut self, anchor_change: &'a AnchorChange) -> Result<()> {
+            let element_index = self.heap.len();
+            self.heap.push(Self::new_trans_element(&anchor_change.anchor, RulesetKind::Filter)?,);
+            self.filter_indices.push((anchor_change, element_index));
+            Ok(())
+        }
+
+        /// Internal function to register redirect element for corresponding AnchorChange
+        fn add_redirect_element(&mut self, anchor_change: &'a AnchorChange) -> Result<()> {
+            let element_index = self.heap.len();
+            self.heap.push(Self::new_trans_element(&anchor_change.anchor, RulesetKind::Redirect)?,);
+            self.redirect_indices.push((anchor_change, element_index));
+            Ok(())
+        }
+
+        /// Internal function to initialize pfioc_trans_e
+        fn new_trans_element(anchor: &str,
+                             ruleset_kind: RulesetKind)
+                             -> Result<ffi::pfvar::pfioc_trans_pfioc_trans_e> {
+            let mut pfioc_trans_e =
+                unsafe { mem::zeroed::<ffi::pfvar::pfioc_trans_pfioc_trans_e>() };
+            pfioc_trans_e.rs_num = ruleset_kind.into();
+            anchor
+                .try_copy_to(&mut pfioc_trans_e.anchor[..])
+                .chain_err(|| ErrorKind::InvalidArgument("Invalid anchor name"))?;
+            Ok(pfioc_trans_e)
+        }
+    }
+}
+use self::private::*;


### PR DESCRIPTION
Previously `Transaction`s were limited to `FilterRule`s only and wouldn't allow to change rules across multiple anchors. Well, not anymore!

This PR adds support for multi-rule and multi-anchor updates by introducing `AnchorChange` that represents the manipulation over anchor that will happen during `Transaction`.

`AnchorChange` has `Optional` arrays of `FilterRule`s and `RedirectRule`s, you may wonder why. Well the reason for that is ability to perform targeted updates, for example: one may decide to update filter rules but leave redirect rules untouched. Running empty transaction would erase the list of rules for corresponding anchor and ruleset kind pair, that's why we should not obtain tickets for rulesets that we do not plan to change.

`Transaction` itself now accepts array of `AnchorChange`s that enables consumers to update multiple anchors in one go. 

It's worth to notice that changes are grouped by anchor and adding `AnchorChange`s for the same anchor twice would only substitute the former value.

Integration tests to follow.