### PR TITLE
Upgrade to bindgen 0.30.0 and adapt ffi code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ assert_matches = "1.1.0"
 uuid = { version = "0.5", features = ["v4"] }
 
 [build-dependencies]
-bindgen = "0.29"
+bindgen = "0.30"

--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,6 @@ fn main() {
 
     let _ = bindgen::builder()
         .header("ffi/pfvar.h")
-        .unstable_rust(false)
         .clang_arg("-DPRIVATE")
         .clang_arg(format!("-I{}/usr/include", sdk_path))
         .clang_arg(format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,9 +387,7 @@ fn setup_pfioc_states(
     let mut pfsync_states = (0..num_states)
         .map(|_| unsafe { mem::zeroed::<ffi::pfvar::pfsync_state>() })
         .collect::<Vec<_>>();
-    unsafe {
-        *pfioc_states.ps_u.psu_states.as_mut() = pfsync_states.as_mut_ptr();
-    }
+    pfioc_states.ps_u.psu_states = pfsync_states.as_mut_ptr();
     (pfioc_states, pfsync_states)
 }
 
@@ -403,8 +401,8 @@ fn setup_pfioc_state_kill(
     pfioc_state_kill.psk_proto_variant = pfsync_state.proto_variant;
     pfioc_state_kill.psk_ifname = pfsync_state.ifname;
     unsafe {
-        pfioc_state_kill.psk_src.addr.v.a.as_mut().addr = pfsync_state.lan.addr;
-        pfioc_state_kill.psk_dst.addr.v.a.as_mut().addr = pfsync_state.ext_lan.addr;
+        pfioc_state_kill.psk_src.addr.v.a.addr = pfsync_state.lan.addr;
+        pfioc_state_kill.psk_dst.addr.v.a.addr = pfsync_state.ext_lan.addr;
     }
 }
 

--- a/src/pooladdr.rs
+++ b/src/pooladdr.rs
@@ -63,7 +63,6 @@ impl TryCopyTo<ffi::pfvar::pf_pooladdr> for PoolAddr {
 /// reference the valid memory.
 ///
 /// One should never use `pf_palist` produced by this class past the lifetime expiration of it.
-#[derive(Debug)]
 pub struct PoolAddrList {
     list: ffi::pfvar::pf_palist,
     pool: Box<[ffi::pfvar::pf_pooladdr]>,

--- a/src/rule/endpoint.rs
+++ b/src/rule/endpoint.rs
@@ -96,7 +96,7 @@ impl TryCopyTo<ffi::pfvar::pf_rule_addr> for Endpoint {
     fn try_copy_to(&self, pf_rule_addr: &mut ffi::pfvar::pf_rule_addr) -> Result<()> {
         self.ip.copy_to(&mut pf_rule_addr.addr);
         self.port
-            .try_copy_to(unsafe { pf_rule_addr.xport.range.as_mut() })?;
+            .try_copy_to(unsafe { &mut pf_rule_addr.xport.range })?;
         Ok(())
     }
 }

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -412,17 +412,16 @@ mod filter_rule_tests {
 impl CopyTo<ffi::pfvar::pf_addr_wrap> for IpNetwork {
     fn copy_to(&self, pf_addr_wrap: &mut ffi::pfvar::pf_addr_wrap) {
         pf_addr_wrap.type_ = ffi::pfvar::PF_ADDR_ADDRMASK as u8;
-        let a = unsafe { pf_addr_wrap.v.a.as_mut() };
-        self.ip().copy_to(&mut a.addr);
-        self.mask().copy_to(&mut a.mask);
+        self.ip().copy_to(unsafe { &mut pf_addr_wrap.v.a.addr });
+        self.mask().copy_to(unsafe { &mut pf_addr_wrap.v.a.mask });
     }
 }
 
 impl CopyTo<ffi::pfvar::pf_addr> for IpAddr {
     fn copy_to(&self, pf_addr: &mut ffi::pfvar::pf_addr) {
         match *self {
-            IpAddr::V4(ip) => ip.copy_to(unsafe { pf_addr.pfa.v4.as_mut() }),
-            IpAddr::V6(ip) => ip.copy_to(unsafe { pf_addr.pfa.v6.as_mut() }),
+            IpAddr::V4(ip) => ip.copy_to(unsafe { &mut pf_addr.pfa.v4 }),
+            IpAddr::V6(ip) => ip.copy_to(unsafe { &mut pf_addr.pfa.v6 }),
         }
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use {ErrorKind, Result, ResultExt};
-use {FilterRule, PoolAddrList, RedirectRule, Route, RulesetKind};
+use {FilterRule, PoolAddrList, RedirectRule, RulesetKind};
 use conversion::TryCopyTo;
 use ffi;
 use std::collections::HashMap;


### PR DESCRIPTION
This is not going to be merged before beta1. Too risky do to such changes so close to a release IMO. If this gets accepted I can merge it after we release the first closed beta.

I wanted to test out what bindgen 0.30 would give us, so I could just as well submit the PR. Apparently now it generates unions instead of awkward structs for C unions. I had to change less than I thought to make it work actually. Most of the changes are because we can access the fields of unions directly instead of going through `.as_mut()` and similar generated helper methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/51)
<!-- Reviewable:end -->
