### PR TITLE
Upgrade rustfmt and clean rustfmt.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
 script:
   - cargo build --verbose
   - sudo cargo test --verbose -- --test-threads=1
+  - sudo chmod -R o+w target/
   # Format only on nightly, since that is where rustfmt-nightly compiles
   - if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
       ./format.sh --write-mode=diff;

--- a/format.sh
+++ b/format.sh
@@ -5,7 +5,7 @@
 
 set -u
 
-VERSION="0.2.6"
+VERSION="0.2.15"
 INSTALL_CMD="cargo install --vers $VERSION --force rustfmt-nightly"
 
 function correct_rustfmt() {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,5 @@
 # Activation of features, almost objectively better ;)
 reorder_imports = true
-reorder_imported_names = true
 reorder_imports_in_group = true
 use_try_shorthand = true
 condense_wildcard_suffices = true
@@ -9,4 +8,3 @@ wrap_comments = true
 
 # Heavily subjective style choices
 comment_width = 100
-take_source_hints = true

--- a/src/rule/ip.rs
+++ b/src/rule/ip.rs
@@ -32,9 +32,7 @@ impl Ip {
 
     /// Returns `Ip::Any` represented an as an `IpNetwork`, used for ffi.
     fn any_ffi_repr() -> IpNetwork {
-        IpNetwork::V6(
-            Ipv6Network::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0), 0).unwrap(),
-        )
+        IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0), 0).unwrap())
     }
 
     /// Returns PoolAddrList initialized with receiver


### PR DESCRIPTION
Because of inactivity in this repo the `rustfmt-nightly` versions have been lagging behind. Here I upgrade it to the latest.

I also remove two directives from the format config:
* `reorder_imported_names` - It is now true by default, so no need to specify it.
* `take_source_hints` - Removing this makes *no* difference. So I don't see the reason to keep it. I tried removing it from `talpid_core` locally as well and it does no difference. So we can probably survive without it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/53)
<!-- Reviewable:end -->
