### PR TITLE
Dont depend on xcodebuild

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,23 +2,17 @@ extern crate bindgen;
 
 use std::env;
 use std::path::Path;
-use std::process::Command;
-use std::str;
 
+#[cfg(target_os = "macos")]
 fn main() {
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR missing from environment");
     println!("OUT_DIR: {}", out_dir);
-    let sdk_path = get_macos_sdk_path();
-    println!("sdk_path: {}", sdk_path);
 
     let _ = bindgen::builder()
         .header("ffi/pfvar.h")
         .clang_arg("-DPRIVATE")
-        .clang_arg(format!("-I{}/usr/include", sdk_path))
-        .clang_arg(format!(
-            "-I{}/System/Library/Frameworks/Kernel.framework/Versions/A/Headers",
-            sdk_path
-        ))
+        .clang_arg("-I/usr/include")
+        .clang_arg("-I/System/Library/Frameworks/Kernel.framework/Versions/A/Headers")
         .whitelist_type("pf_status")
         .whitelist_type("pfioc_rule")
         .whitelist_type("pfioc_pooladdr")
@@ -32,11 +26,7 @@ fn main() {
         .expect("Unable to write pfvar.rs");
 }
 
-fn get_macos_sdk_path() -> String {
-    let output = Command::new("xcodebuild")
-        .args(&["-sdk", "macosx", "Path", "-version"])
-        .output()
-        .expect("Unable to get macOS SDK path with \"xcodebuild\"");
-    let stdout = str::from_utf8(&output.stdout).expect("xcodebuild did not print valid utf-8");
-    stdout.trim().to_owned()
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    panic!("This crate can only be built on macOS");
 }

--- a/examples/add_rules.rs
+++ b/examples/add_rules.rs
@@ -10,7 +10,7 @@
 extern crate error_chain;
 extern crate pfctl;
 
-use pfctl::{FilterRuleBuilder, PfCtl, RedirectRuleBuilder, ipnetwork};
+use pfctl::{ipnetwork, FilterRuleBuilder, PfCtl, RedirectRuleBuilder};
 use std::net::Ipv4Addr;
 
 error_chain!{}

--- a/format.sh
+++ b/format.sh
@@ -5,7 +5,7 @@
 
 set -u
 
-VERSION="0.3.2"
+VERSION="0.3.4"
 INSTALL_CMD="cargo install --vers $VERSION --force rustfmt-nightly"
 
 function correct_rustfmt() {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -180,8 +180,7 @@ impl Transaction {
         anchor: &str,
         ruleset_kind: RulesetKind,
     ) -> Result<ffi::pfvar::pfioc_trans_pfioc_trans_e> {
-        let mut pfioc_trans_e =
-            unsafe { mem::zeroed::<ffi::pfvar::pfioc_trans_pfioc_trans_e>() };
+        let mut pfioc_trans_e = unsafe { mem::zeroed::<ffi::pfvar::pfioc_trans_pfioc_trans_e>() };
         pfioc_trans_e.rs_num = ruleset_kind.into();
         anchor
             .try_copy_to(&mut pfioc_trans_e.anchor[..])

--- a/tests/anchors.rs
+++ b/tests/anchors.rs
@@ -1,6 +1,6 @@
-extern crate pfctl;
 #[macro_use]
 extern crate error_chain;
+extern crate pfctl;
 
 #[macro_use]
 extern crate assert_matches;

--- a/tests/enable_disable.rs
+++ b/tests/enable_disable.rs
@@ -1,6 +1,6 @@
-extern crate pfctl;
 #[macro_use]
 extern crate error_chain;
+extern crate pfctl;
 
 #[macro_use]
 extern crate assert_matches;

--- a/tests/filter_rules.rs
+++ b/tests/filter_rules.rs
@@ -1,6 +1,6 @@
-extern crate pfctl;
 #[macro_use]
 extern crate error_chain;
+extern crate pfctl;
 
 #[macro_use]
 extern crate assert_matches;

--- a/tests/redirect_rules.rs
+++ b/tests/redirect_rules.rs
@@ -1,6 +1,6 @@
-extern crate pfctl;
 #[macro_use]
 extern crate error_chain;
+extern crate pfctl;
 
 #[macro_use]
 extern crate assert_matches;

--- a/tests/states.rs
+++ b/tests/states.rs
@@ -1,6 +1,6 @@
-extern crate pfctl;
 #[macro_use]
 extern crate error_chain;
+extern crate pfctl;
 
 #[macro_use]
 extern crate assert_matches;

--- a/tests/transaction.rs
+++ b/tests/transaction.rs
@@ -1,6 +1,6 @@
-extern crate pfctl;
 #[macro_use]
 extern crate error_chain;
+extern crate pfctl;
 
 #[macro_use]
 extern crate assert_matches;


### PR DESCRIPTION
So I found this less dramatic change to get the same result as #58. However, I'm not determined as to which solution is the best one yet.

You know more about macOS than me, will this solution work on a machine without xcode or the SDK installed? Will the global `/System/Library/Frameworks/Kernel.framework/Versions/A/Headers` folder exist on such machine, or is it just mine+travis because we also have xcode installed already?

This solution is cleaner in the sense that we don't have to commit 4000 lines of generated Rust code. One con of this solution is that the crate can still only be built on a macOS machine. If we did not depend on the headers at all and checked in the generated code it would likely build (but not run) on any platform, which would make it a bit easier to depend on this crate and to generate the docs on non-MACs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/59)
<!-- Reviewable:end -->
