### PR TITLE
Upgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [unreleased]
 
 
+## [0.2.0] - 2018-06-25
+### Changed
+- Upgrade re-exported dependency ipnetwork to 0.13.
+- Upgrade error-chain to 0.12 and re-export it.
+
+
 ## [0.1.1] - 2018-01-08
 ### Changed
 - Removed building the C bindings in build.rs. Instead commit the generated bindings directly in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ error-chain = "0.11"
 ioctl-sys = "0.5.2"
 libc = "0.2.29"
 derive_builder = "0.5"
-ipnetwork = "0.12"
+ipnetwork = "0.13"
 
 [dev-dependencies]
 lazy_static = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pfctl"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <faern@faern.net>", "Andrej Mihajlov <and@mullvad.net>"]
 license = "MIT/Apache-2.0"
 description = "Library for interfacing with the Packet Filter (PF) firewall on macOS"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ travis-ci = { repository = "mullvad/pfctl-rs" }
 
 [dependencies]
 errno = "0.2"
-error-chain = "0.11"
+error-chain = "0.12"
 ioctl-sys = "0.5.2"
 libc = "0.2.29"
 derive_builder = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ ipnetwork = "0.13"
 [dev-dependencies]
 lazy_static = "1.0"
 assert_matches = "1.1.0"
-uuid = { version = "0.5", features = ["v4"] }
+uuid = { version = "0.6", features = ["v4"] }
 scopeguard = "0.3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 extern crate derive_builder;
 extern crate errno;
 #[macro_use]
-extern crate error_chain;
+pub extern crate error_chain;
 #[macro_use]
 extern crate ioctl_sys;
 extern crate libc;


### PR DESCRIPTION
Needed to upgrade `error-chain` to 0.12 for smooth upgrade in `mullvadvpn-app`. Also upgraded some other dependencies while at it.

The plan is to publish `0.2.0` when this is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/62)
<!-- Reviewable:end -->
