### PR TITLE
Upgrade all dependencies to latest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - nightly
   - stable
   - beta
-  - 1.31.0
+  - 1.32.0
 os:
   - osx
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 * **Security**: in case of vulnerabilities.
 
 ## [unreleased]
+
+
+## [0.3.0] - 2019-09-13
 ### Changed
-- Upgraded the crate to Rust 2018. Minimum Rust version is now 1.31.0
+- Upgrade the crate to Rust 2018.
+- Upgrade publicly re-exported dependency `ipnetwork` to 0.15.0.
+- Minimum Rust version is now 1.32.0
 
 
 ## [0.2.0] - 2018-06-25

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ errno = "0.2"
 error-chain = "0.12"
 ioctl-sys = "0.5.2"
 libc = "0.2.29"
-derive_builder = "0.5"
-ipnetwork = "0.14"
+derive_builder = "0.7"
+ipnetwork = "0.15"
 
 [dev-dependencies]
 assert_matches = "1.1.0"
-uuid = { version = "0.6", features = ["v4"] }
-scopeguard = "0.3.2"
+uuid = { version = "0.7", features = ["v4"] }
+scopeguard = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pfctl"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <faern@faern.net>", "Andrej Mihajlov <and@mullvad.net>"]
 license = "MIT/Apache-2.0"
 description = "Library for interfacing with the Packet Filter (PF) firewall on macOS"

--- a/tests/anchors.rs
+++ b/tests/anchors.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 fn unique_anchor() -> String {
     format!(
         "pfctl-rs.integration.testing.{}",
-        Uuid::new_v4().simple().to_string()
+        Uuid::new_v4().to_simple().to_string()
     )
 }
 


### PR DESCRIPTION
`ipnetwork 0.15` was just released. We want to use that in the Mullvad VPN app. But to avoid some compatibility shim code we need to have the same version in the app as in this dependency. So I went ahead and upgraded it in this library as well. And found out via `cargo outdated` that there were a number of outdated dependencies here. So I upgraded all of them. Only `uuid` caused something to break, but it was an easy fix to adapt to.