### PR TITLE
Update minimum Rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - nightly
   - stable
   - beta
-  - 1.32.0
+  - 1.38.0
 os:
   - osx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ script:
   - sudo cargo test --verbose -- --test-threads=1
   - sudo chmod -R o+w target/
   # Format only on nightly, since that is where rustfmt-nightly compiles
-  - if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
-      rustup component add rustfmt-preview;
+  - if [ "${TRAVIS_RUST_VERSION}" = "stable" ]; then
+      rustup component add rustfmt;
       rustfmt --version;
-      cargo fmt -- --check --unstable-features;
+      cargo fmt -- --check;
     else
       echo "Not checking formatting on this build";
     fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [unreleased]
 ### Added
 - Add support for user and group IDs to rules.
+- Add option to reject packets instead of simply dropping them.
 
 ### Changed
 - Minimum Rust version is now 1.38.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add support for user and group IDs to rules.
 
+### Changed
+- Minimum Rust version is now 1.38.0
+
 
 ## [0.3.0] - 2019-09-13
 ### Changed

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,9 +1,2 @@
 # Activation of features, almost objectively better ;)
 use_try_shorthand = true
-condense_wildcard_suffixes = true
-normalize_comments = true
-wrap_comments = true
-
-# Heavily subjective style choices
-comment_width = 100
-blank_lines_upper_bound = 2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,6 @@ mod errors {
 }
 pub use crate::errors::*;
 
-
 /// Returns the given input result, except if it is an `Err` matching the given `ErrorKind`,
 /// then it returns `Ok(())` instead, so the error is ignored.
 macro_rules! ignore_error_kind {
@@ -129,7 +128,6 @@ macro_rules! ignore_error_kind {
         }
     };
 }
-
 
 /// Module for types and traits dealing with translating between Rust and FFI.
 mod conversion {
@@ -146,14 +144,12 @@ mod conversion {
 }
 use crate::conversion::*;
 
-
 /// Internal function to safely compare Rust string with raw C string slice
 fn compare_cstr_safe(s: &str, cchars: &[std::os::raw::c_char]) -> Result<bool> {
     ensure!(cchars.iter().any(|&c| c == 0), "Not null terminated");
     let cs = unsafe { CStr::from_ptr(cchars.as_ptr()) };
     Ok(s.as_bytes() == cs.to_bytes())
 }
-
 
 /// Struct communicating with the PF firewall.
 pub struct PfCtl {
@@ -367,7 +363,6 @@ impl PfCtl {
     }
 }
 
-
 /// Creates pfioc_states and returns a tuple of pfioc_states and vector of pfsync_state with the
 /// given number of elements.
 /// Since pfioc_states uses raw memory pointer to Vec<pfsync_state>, make sure that
@@ -397,7 +392,6 @@ fn setup_pfioc_state_kill(
     pfioc_state_kill.psk_src.addr.v.a.addr = pfsync_state.lan.addr;
     pfioc_state_kill.psk_dst.addr.v.a.addr = pfsync_state.ext_lan.addr;
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/rule/gid.rs
+++ b/src/rule/gid.rs
@@ -13,10 +13,8 @@ use crate::{
     Result,
 };
 
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Gid(pub Id);
-
 
 impl Default for Gid {
     fn default() -> Self {

--- a/src/rule/ip.rs
+++ b/src/rule/ip.rs
@@ -41,7 +41,6 @@ impl Ip {
     }
 }
 
-
 impl Default for Ip {
     fn default() -> Self {
         Ip::Any

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -59,7 +59,6 @@ pub use self::uid::*;
 mod gid;
 pub use self::gid::*;
 
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Builder)]
 #[builder(setter(into))]
 #[builder(build_fn(name = "build_internal"))]
@@ -161,7 +160,6 @@ impl TryCopyTo<ffi::pfvar::pf_rule> for FilterRule {
     }
 }
 
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Builder)]
 #[builder(setter(into))]
 #[builder(build_fn(name = "build_internal"))]
@@ -236,7 +234,6 @@ impl TryCopyTo<ffi::pfvar::pf_rule> for RedirectRule {
     }
 }
 
-
 fn compatible_af(af1: AddrFamily, af2: AddrFamily) -> Result<AddrFamily> {
     match (af1, af2) {
         (af1, af2) if af1 == af2 => Ok(af1),
@@ -248,7 +245,6 @@ fn compatible_af(af1: AddrFamily, af2: AddrFamily) -> Result<AddrFamily> {
         }
     }
 }
-
 
 #[cfg(test)]
 mod filter_rule_tests {
@@ -442,7 +438,6 @@ mod filter_rule_tests {
             .is_err());
     }
 }
-
 
 // Implementations to convert types that are not ours into their FFI representation
 

--- a/src/rule/port.rs
+++ b/src/rule/port.rs
@@ -84,7 +84,6 @@ impl TryCopyTo<ffi::pfvar::pf_pool> for Port {
     }
 }
 
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PortUnaryModifier {
     Equal,
@@ -107,7 +106,6 @@ impl From<PortUnaryModifier> for u8 {
         }
     }
 }
-
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PortRangeModifier {

--- a/src/rule/rule_action.rs
+++ b/src/rule/rule_action.rs
@@ -58,7 +58,6 @@ impl From<DropAction> for u32 {
     }
 }
 
-
 /// Enum describing what should happen to a packet that matches a redirect rule.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RedirectRuleAction {

--- a/src/rule/tcp_flags.rs
+++ b/src/rule/tcp_flags.rs
@@ -43,7 +43,6 @@ impl From<TcpFlag> for u8 {
     }
 }
 
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct TcpFlagSet(Vec<TcpFlag>);
 
@@ -52,7 +51,6 @@ impl<'a> From<&'a TcpFlagSet> for u8 {
         set.0.iter().fold(0, |acc, &x| (acc | u8::from(x)))
     }
 }
-
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct TcpFlags {

--- a/src/rule/uid.rs
+++ b/src/rule/uid.rs
@@ -19,7 +19,6 @@ pub enum Id {
     Range(u32, u32, IdRangeModifier),
 }
 
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Uid(pub Id);
 
@@ -34,7 +33,6 @@ impl From<u32> for Uid {
         Uid(Id::One(uid, IdUnaryModifier::Equal))
     }
 }
-
 
 impl From<Id> for Uid {
     fn from(id: Id) -> Self {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -191,7 +191,6 @@ impl Transaction {
     }
 }
 
-
 /// Structure that describes anchor rules manipulation allowing for targeted changes in anchors.
 /// The rules set to this structure will replace the active rules by transaction.
 /// Not setting either of rules will leave active rules untouched by transaction.

--- a/tests/helper/pfcli.rs
+++ b/tests/helper/pfcli.rs
@@ -98,7 +98,6 @@ pub fn get_all_states() -> Result<Vec<String>> {
     Ok(states)
 }
 
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FlushOptions {
     All,


### PR DESCRIPTION
[`pointer.cast()`](https://doc.rust-lang.org/std/primitive.pointer.html#method.cast) was stabilized in version 1.38.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/71)
<!-- Reviewable:end -->
