### PR TITLE
Cleanup and dependency upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ errno = "0.2"
 error-chain = "0.12"
 ioctl-sys = "0.5.2"
 libc = "0.2.29"
-derive_builder = "0.7"
-ipnetwork = "0.15"
+derive_builder = "0.9"
+ipnetwork = "0.16"
 
 [dev-dependencies]
 assert_matches = "1.1.0"
-uuid = { version = "0.7", features = ["v4"] }
+uuid = { version = "0.8", features = ["v4"] }
 scopeguard = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pfctl"
 version = "0.3.0"
-authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <faern@faern.net>", "Andrej Mihajlov <and@mullvad.net>"]
+authors = ["Mullvad VPN"]
 license = "MIT/Apache-2.0"
 description = "Library for interfacing with the Packet Filter (PF) firewall on macOS"
 repository = "https://github.com/mullvad/pfctl-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,8 @@
 //! [integration tests]: https://github.com/mullvad/pfctl-rs/tree/master/tests
 //! [examples]: https://github.com/mullvad/pfctl-rs/tree/master/examples
 
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 pub extern crate error_chain;
 


### PR DESCRIPTION
In order to not have to maintain a long list of authors, that very easily become outdated, we have started just stating "Mullvad VPN" as authors. So this PR does that.

But while I did that I also saw we had some outdated dependencies. And we also usually deny code not fitting with Rust 2018 edition style. So I fixed these things at the same time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/73)
<!-- Reviewable:end -->
