### PR TITLE
Fix Apple Silicon build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - nightly
   - stable
   - beta
-  - 1.38.0
+  - 1.40.0
 os:
   - osx
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 
+### Changed
+- Upgrade ioctl-sys to 0.6.0.
+- Minimum Rust version is now 1.40.0
 
 ## [0.4.0] - 2020-06-09
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "mullvad/pfctl-rs" }
 [dependencies]
 errno = "0.2"
 error-chain = "0.12"
-ioctl-sys = "0.5.2"
+ioctl-sys = "0.6.0"
 libc = "0.2.29"
 derive_builder = "0.9"
 ipnetwork = "0.16"

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use ioctl_sys::{io, ioc, ioctl, iorw};
+use ioctl_sys::ioctl;
 
 #[allow(non_camel_case_types)]
 #[allow(non_upper_case_globals)]


### PR DESCRIPTION
Update the `ioctl-sys` dependency to enable build on Apple Silicon.

Fixes #74

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/75)
<!-- Reviewable:end -->
