### PR TITLE
Add initial support for checking ICMP type and code fields in rules

### DIFF
--- a/examples/add_rules.rs
+++ b/examples/add_rules.rs
@@ -41,6 +41,13 @@ fn run() -> Result<()> {
         .interface("utun0")
         .build()
         .unwrap();
+    let pass_all_icmp_echo_req = FilterRuleBuilder::default()
+        .action(pfctl::FilterRuleAction::Pass)
+        .af(pfctl::AddrFamily::Ipv4)
+        .proto(pfctl::Proto::Icmp)
+        .icmp_type(pfctl::IcmpType::EchoReq)
+        .build()
+        .unwrap();
 
     // Block packets from the entire 10.0.0.0/8 private network.
     let private_net = ipnetwork::Ipv4Network::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap();
@@ -71,6 +78,8 @@ fn run() -> Result<()> {
     pf.add_rule(ANCHOR_NAME, &pass_all_ipv6_on_utun0_rule)
         .chain_err(|| "Unable to add rule")?;
     pf.add_rule(ANCHOR_NAME, &block_a_private_net_rule)
+        .chain_err(|| "Unable to add rule")?;
+    pf.add_rule(ANCHOR_NAME, &pass_all_icmp_echo_req)
         .chain_err(|| "Unable to add rule")?;
     pf.add_redirect_rule(ANCHOR_NAME, &redirect_incoming_tcp_from_port_3000_to_4000)
         .chain_err(|| "Unable to add redirect rule")?;

--- a/src/rule/icmp.rs
+++ b/src/rule/icmp.rs
@@ -1,0 +1,87 @@
+// Copyright 2021 Mullvad VPN AB.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// ICMP type (and code). Used to match a rule against an ICMP packets `type` and `code` fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum IcmpType {
+    /// Echo reply.
+    EchoRep,
+    /// Destination unreachable
+    Unreach(IcmpUnreachCode),
+    /// Echo request.
+    EchoReq,
+    /// Traceroute.
+    Trace,
+    /// ICMPv6
+    Icmp6(Icmp6Type),
+}
+
+/// ICMP code fields for destination unreachable ICMP packet's ([`IcmpType::Unreach`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum IcmpUnreachCode {
+    /// Network unreachable.
+    NetUnreach = 0,
+    /// Host unreachable.
+    HostUnreach = 1,
+    /// Protocol unreachable.
+    ProtoUnreach = 2,
+    /// Port unreachable.
+    PortUnreach = 3,
+    /// Fragmentation needed but DF bit set.
+    NeedFrag = 4,
+}
+
+/// Values for the `type` field in ICMPv6 packets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum Icmp6Type {
+    /// Router solicitation.
+    RouterSol = 133,
+    /// Router advertisement.
+    RouterAdv = 134,
+    /// Neighbor solicitation.
+    NeighbrSol = 135,
+    /// Neighbor advertisement.
+    NeighbrAdv = 136,
+}
+
+impl IcmpType {
+    /// Returns the FFI representation for this ICMP type
+    fn raw_type(&self) -> u8 {
+        use IcmpType::*;
+        match self {
+            EchoRep => 0,
+            Unreach(_) => 3,
+            EchoReq => 8,
+            Trace => 30,
+            Icmp6(icmp6_type) => *icmp6_type as u8,
+        }
+    }
+
+    /// Returns the FFI representation of the code for this ICMP type
+    fn raw_code(&self) -> u8 {
+        use IcmpType::*;
+        match self {
+            Unreach(unreach_code) => *unreach_code as u8,
+            _ => 0,
+        }
+    }
+}
+
+impl crate::conversion::CopyTo<crate::ffi::pfvar::pf_rule> for IcmpType {
+    fn copy_to(&self, pf_rule: &mut crate::ffi::pfvar::pf_rule) {
+        // The field should be set to one higher than the constants.
+        // See OpenBSD implementation of the `pfctl` CLI tool for reference.
+        pf_rule.type_ = self.raw_type() + 1;
+        pf_rule.code = self.raw_code() + 1;
+    }
+}

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -23,6 +23,12 @@ pub use self::direction::*;
 mod endpoint;
 pub use self::endpoint::*;
 
+mod gid;
+pub use self::gid::*;
+
+mod icmp;
+pub use self::icmp::*;
+
 mod ip;
 pub use self::ip::*;
 
@@ -52,9 +58,6 @@ pub use self::rule_log::*;
 
 mod uid;
 pub use self::uid::*;
-
-mod gid;
-pub use self::gid::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Builder)]
 #[builder(setter(into))]
@@ -89,6 +92,8 @@ pub struct FilterRule {
     user: Uid,
     #[builder(default)]
     group: Gid,
+    #[builder(default)]
+    icmp_type: Option<IcmpType>,
 }
 
 impl FilterRuleBuilder {
@@ -152,6 +157,9 @@ impl TryCopyTo<ffi::pfvar::pf_rule> for FilterRule {
         self.label.try_copy_to(&mut pf_rule.label)?;
         self.user.try_copy_to(&mut pf_rule.uid)?;
         self.group.try_copy_to(&mut pf_rule.gid)?;
+        if let Some(icmp_type) = self.icmp_type {
+            icmp_type.copy_to(pf_rule);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
I did not implement all possible ICMP type and code field values. A lot of work for no immediate gain. I implemented the ones we need right now plus some values I regarded as probably being pretty common/useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/79)
<!-- Reviewable:end -->
