### PR TITLE
Fix: Don't set the `code` field for ICMP types that don't use it

### DIFF
--- a/examples/add_rules.rs
+++ b/examples/add_rules.rs
@@ -48,6 +48,15 @@ fn run() -> Result<()> {
         .icmp_type(pfctl::IcmpType::EchoReq)
         .build()
         .unwrap();
+    let pass_all_icmp_port_unreach = FilterRuleBuilder::default()
+        .action(pfctl::FilterRuleAction::Pass)
+        .af(pfctl::AddrFamily::Ipv4)
+        .proto(pfctl::Proto::Icmp)
+        .icmp_type(pfctl::IcmpType::Unreach(
+            pfctl::IcmpUnreachCode::PortUnreach,
+        ))
+        .build()
+        .unwrap();
 
     // Block packets from the entire 10.0.0.0/8 private network.
     let private_net = ipnetwork::Ipv4Network::new(Ipv4Addr::new(10, 0, 0, 0), 8).unwrap();
@@ -80,6 +89,8 @@ fn run() -> Result<()> {
     pf.add_rule(ANCHOR_NAME, &block_a_private_net_rule)
         .chain_err(|| "Unable to add rule")?;
     pf.add_rule(ANCHOR_NAME, &pass_all_icmp_echo_req)
+        .chain_err(|| "Unable to add rule")?;
+    pf.add_rule(ANCHOR_NAME, &pass_all_icmp_port_unreach)
         .chain_err(|| "Unable to add rule")?;
     pf.add_redirect_rule(ANCHOR_NAME, &redirect_incoming_tcp_from_port_3000_to_4000)
         .chain_err(|| "Unable to add redirect rule")?;

--- a/src/rule/icmp.rs
+++ b/src/rule/icmp.rs
@@ -67,12 +67,13 @@ impl IcmpType {
         }
     }
 
-    /// Returns the FFI representation of the code for this ICMP type
-    fn raw_code(&self) -> u8 {
+    /// Returns the FFI representation of the code for this ICMP type.
+    /// Returns `None` if this ICMP type does not use the code field.
+    fn raw_code(&self) -> Option<u8> {
         use IcmpType::*;
         match self {
-            Unreach(unreach_code) => *unreach_code as u8,
-            _ => 0,
+            Unreach(unreach_code) => Some(*unreach_code as u8),
+            _ => None,
         }
     }
 }
@@ -82,6 +83,9 @@ impl crate::conversion::CopyTo<crate::ffi::pfvar::pf_rule> for IcmpType {
         // The field should be set to one higher than the constants.
         // See OpenBSD implementation of the `pfctl` CLI tool for reference.
         pf_rule.type_ = self.raw_type() + 1;
-        pf_rule.code = self.raw_code() + 1;
+        pf_rule.code = match self.raw_code() {
+            Some(raw_code) => raw_code + 1,
+            None => 0,
+        };
     }
 }


### PR DESCRIPTION
Fixes a bug in #79 where we always set the `pf_rule::code` field to a non-zero value. The value zero indicates that the rule should not even check the code field. For most ICMP `type` values there is no corresponding `code` value and it does not make much sense to check it.

Both this and the previous design prevents rules from checking the code value for arbitrary numbers. A theoretical rule could be `icmp-type echoreq code 123`. It would be a valid rule and there could theoretically be packets matching it, but it would not make much sense from a practical standpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/80)
<!-- Reviewable:end -->
