### PR TITLE
Change `error-chain` to `thiserror`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,14 @@ travis-ci = { repository = "mullvad/pfctl-rs" }
 
 [dependencies]
 errno = "0.2"
-error-chain = "0.12"
 ioctl-sys = "0.6.0"
 libc = "0.2.29"
 derive_builder = "0.9"
 ipnetwork = "0.16"
+thiserror = "1"
 
 [dev-dependencies]
 assert_matches = "1.1.0"
+error-chain = "0.12"
 uuid = { version = "0.8", features = ["v4"] }
 scopeguard = "1.0"

--- a/examples/enable.rs
+++ b/examples/enable.rs
@@ -21,7 +21,7 @@ fn run() -> Result<()> {
     // Try to enable the firewall. Equivalent to the CLI command "pfctl -e".
     match pf.enable() {
         Ok(_) => println!("Enabled PF"),
-        Err(pfctl::Error(pfctl::ErrorKind::StateAlreadyActive, _)) => (),
+        Err(pfctl::Error::StateAlreadyActive(_)) => (),
         err => err.chain_err(|| "Unable to enable PF")?,
     }
     Ok(())

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,12 +16,12 @@ macro_rules! ioctl_guard {
     ($func:expr, $already_active:expr) => {
         if unsafe { $func } == $crate::macros::IOCTL_ERROR {
             let ::errno::Errno(error_code) = ::errno::errno();
-            let io_error = ::std::io::Error::from_raw_os_error(error_code);
-            let mut err = Err($crate::ErrorKind::IoctlError(io_error).into());
+            let err = ::std::io::Error::from_raw_os_error(error_code);
             if error_code == $already_active {
-                err = err.chain_err(|| $crate::ErrorKind::StateAlreadyActive);
+                Err($crate::Error::StateAlreadyActive(err))
+            } else {
+                Err($crate::Error::from(err))
             }
-            err
         } else {
             Ok(()) as $crate::Result<()>
         }

--- a/src/rule/endpoint.rs
+++ b/src/rule/endpoint.rs
@@ -92,7 +92,9 @@ impl From<SocketAddr> for Endpoint {
 }
 
 impl TryCopyTo<ffi::pfvar::pf_rule_addr> for Endpoint {
-    fn try_copy_to(&self, pf_rule_addr: &mut ffi::pfvar::pf_rule_addr) -> Result<()> {
+    type Result = Result<()>;
+
+    fn try_copy_to(&self, pf_rule_addr: &mut ffi::pfvar::pf_rule_addr) -> Self::Result {
         self.ip.copy_to(&mut pf_rule_addr.addr);
         self.port
             .try_copy_to(unsafe { &mut pf_rule_addr.xport.range })?;

--- a/src/rule/gid.rs
+++ b/src/rule/gid.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub use super::uid::{Id, IdUnaryModifier};
+pub use super::uid::Id;
 use crate::{
     conversion::TryCopyTo,
     ffi::pfvar::{pf_rule_gid, PF_OP_NONE},
@@ -29,7 +29,9 @@ impl<T: Into<Id>> From<T> for Gid {
 }
 
 impl TryCopyTo<pf_rule_gid> for Gid {
-    fn try_copy_to(&self, pf_rule_gid: &mut pf_rule_gid) -> Result<()> {
+    type Result = Result<()>;
+
+    fn try_copy_to(&self, pf_rule_gid: &mut pf_rule_gid) -> Self::Result {
         match self.0 {
             Id::Any => {
                 pf_rule_gid.gid[0] = 0;

--- a/src/rule/interface.rs
+++ b/src/rule/interface.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{conversion::TryCopyTo, Result};
+use crate::{conversion::TryCopyTo, TryCopyToResult};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InterfaceName(String);
@@ -36,7 +36,9 @@ impl<T: AsRef<str>> From<T> for Interface {
 }
 
 impl TryCopyTo<[i8]> for Interface {
-    fn try_copy_to(&self, dst: &mut [i8]) -> Result<()> {
+    type Result = TryCopyToResult<()>;
+
+    fn try_copy_to(&self, dst: &mut [i8]) -> Self::Result {
         match *self {
             Interface::Any => "",
             Interface::Name(InterfaceName(ref name)) => &name[..],

--- a/src/rule/ip.rs
+++ b/src/rule/ip.rs
@@ -10,7 +10,7 @@ use crate::{
     conversion::CopyTo,
     ffi,
     pooladdr::{PoolAddr, PoolAddrList},
-    AddrFamily, Result,
+    AddrFamily, TryCopyToResult,
 };
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -36,7 +36,7 @@ impl Ip {
     }
 
     /// Returns PoolAddrList initialized with receiver
-    pub fn to_pool_addr_list(&self) -> Result<PoolAddrList> {
+    pub fn to_pool_addr_list(&self) -> TryCopyToResult<PoolAddrList> {
         PoolAddrList::new(&[PoolAddr::from(*self)])
     }
 }

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -8,7 +8,8 @@
 
 use crate::{
     conversion::{CopyTo, TryCopyTo},
-    ffi, ErrorKind, Result, ResultExt,
+    ffi, Error, Result, TryCopyToError, TryCopyToErrorKind, TryCopyToErrorWithKind,
+    TryCopyToResult,
 };
 use derive_builder::Builder;
 use ipnetwork::IpNetwork;
@@ -98,8 +99,7 @@ pub struct FilterRule {
 
 impl FilterRuleBuilder {
     pub fn build(&self) -> Result<FilterRule> {
-        self.build_internal()
-            .map_err(|e| ErrorKind::InvalidRuleCombination(e).into())
+        self.build_internal().map_err(Error::InvalidRuleCombination)
     }
 }
 
@@ -128,14 +128,16 @@ impl FilterRule {
                     "StatePolicy {:?} and protocol {:?} are incompatible",
                     state_policy, proto
                 );
-                bail!(ErrorKind::InvalidRuleCombination(msg));
+                Err(Error::InvalidRuleCombination(msg))
             }
         }
     }
 }
 
 impl TryCopyTo<ffi::pfvar::pf_rule> for FilterRule {
-    fn try_copy_to(&self, pf_rule: &mut ffi::pfvar::pf_rule) -> Result<()> {
+    type Result = Result<()>;
+
+    fn try_copy_to(&self, pf_rule: &mut ffi::pfvar::pf_rule) -> Self::Result {
         pf_rule.action = self.action.into();
         pf_rule.direction = self.direction.into();
         pf_rule.quick = self.quick as u8;
@@ -148,7 +150,9 @@ impl TryCopyTo<ffi::pfvar::pf_rule> for FilterRule {
 
         self.interface
             .try_copy_to(&mut pf_rule.ifname)
-            .chain_err(|| ErrorKind::InvalidArgument("Incompatible interface name"))?;
+            .map_err(|e| {
+                TryCopyToErrorWithKind::new(TryCopyToErrorKind::IncompatibleInterfaceName, e)
+            })?;
         pf_rule.proto = self.proto.into();
         pf_rule.af = self.get_af()?.into();
 
@@ -197,8 +201,7 @@ pub struct RedirectRule {
 
 impl RedirectRuleBuilder {
     pub fn build(&self) -> Result<RedirectRule> {
-        self.build_internal()
-            .map_err(|e| ErrorKind::InvalidRuleCombination(e).into())
+        self.build_internal().map_err(Error::InvalidRuleCombination)
     }
 }
 
@@ -218,14 +221,18 @@ impl RedirectRule {
 }
 
 impl TryCopyTo<ffi::pfvar::pf_rule> for RedirectRule {
-    fn try_copy_to(&self, pf_rule: &mut ffi::pfvar::pf_rule) -> Result<()> {
+    type Result = Result<()>;
+
+    fn try_copy_to(&self, pf_rule: &mut ffi::pfvar::pf_rule) -> Self::Result {
         pf_rule.action = self.action.into();
         pf_rule.direction = self.direction.into();
         pf_rule.quick = self.quick as u8;
         pf_rule.log = (&self.log).into();
         self.interface
             .try_copy_to(&mut pf_rule.ifname)
-            .chain_err(|| ErrorKind::InvalidArgument("Incompatible interface name"))?;
+            .map_err(|e| {
+                TryCopyToErrorWithKind::new(TryCopyToErrorKind::IncompatibleInterfaceName, e)
+            })?;
         pf_rule.proto = self.proto.into();
         pf_rule.af = self.get_af()?.into();
 
@@ -246,7 +253,7 @@ fn compatible_af(af1: AddrFamily, af2: AddrFamily) -> Result<AddrFamily> {
         (AddrFamily::Any, af) => Ok(af),
         (af1, af2) => {
             let msg = format!("AddrFamily {} and {} are incompatible", af1, af2);
-            bail!(ErrorKind::InvalidRuleCombination(msg));
+            Err(Error::InvalidRuleCombination(msg))
         }
     }
 }
@@ -480,19 +487,19 @@ impl CopyTo<ffi::pfvar::in6_addr> for Ipv6Addr {
 }
 
 impl<T: AsRef<str>> TryCopyTo<[i8]> for T {
+    type Result = TryCopyToResult<()>;
+
     /// Safely copy a Rust string into a raw buffer. Returning an error if the string could not
     /// be copied to the buffer.
-    fn try_copy_to(&self, dst: &mut [i8]) -> Result<()> {
+    fn try_copy_to(&self, dst: &mut [i8]) -> Self::Result {
         let src_i8: &[i8] = unsafe { &*(self.as_ref().as_bytes() as *const _ as *const _) };
 
-        ensure!(
-            src_i8.len() < dst.len(),
-            ErrorKind::InvalidArgument("String does not fit destination")
-        );
-        ensure!(
-            !src_i8.contains(&0),
-            ErrorKind::InvalidArgument("String has null byte")
-        );
+        if src_i8.len() >= dst.len() {
+            return Err(TryCopyToError::InsufficientStringBufferLength);
+        }
+        if src_i8.contains(&0) {
+            return Err(TryCopyToError::StringContainsNullByte);
+        }
 
         dst[..src_i8.len()].copy_from_slice(src_i8);
         // Terminate ffi string with null byte

--- a/src/rule/port.rs
+++ b/src/rule/port.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{conversion::TryCopyTo, ffi, ErrorKind, Result};
+use crate::{conversion::TryCopyTo, ffi, TryCopyToError, TryCopyToResult};
 
 // Port range representation
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -29,7 +29,9 @@ impl From<u16> for Port {
 }
 
 impl TryCopyTo<ffi::pfvar::pf_port_range> for Port {
-    fn try_copy_to(&self, pf_port_range: &mut ffi::pfvar::pf_port_range) -> Result<()> {
+    type Result = TryCopyToResult<()>;
+
+    fn try_copy_to(&self, pf_port_range: &mut ffi::pfvar::pf_port_range) -> Self::Result {
         match *self {
             Port::Any => {
                 pf_port_range.op = ffi::pfvar::PF_OP_NONE as u8;
@@ -43,10 +45,9 @@ impl TryCopyTo<ffi::pfvar::pf_port_range> for Port {
                 pf_port_range.port[1] = 0;
             }
             Port::Range(start_port, end_port, modifier) => {
-                ensure!(
-                    start_port <= end_port,
-                    ErrorKind::InvalidArgument("Lower port is greater than upper port.")
-                );
+                if start_port > end_port {
+                    return Err(TryCopyToError::InvalidPortRange);
+                }
                 pf_port_range.op = modifier.into();
                 // convert port range to network byte order
                 pf_port_range.port[0] = start_port.to_be();
@@ -58,7 +59,9 @@ impl TryCopyTo<ffi::pfvar::pf_port_range> for Port {
 }
 
 impl TryCopyTo<ffi::pfvar::pf_pool> for Port {
-    fn try_copy_to(&self, pf_pool: &mut ffi::pfvar::pf_pool) -> Result<()> {
+    type Result = TryCopyToResult<()>;
+
+    fn try_copy_to(&self, pf_pool: &mut ffi::pfvar::pf_pool) -> Self::Result {
         match *self {
             Port::Any => {
                 pf_pool.port_op = ffi::pfvar::PF_OP_NONE as u8;
@@ -71,10 +74,9 @@ impl TryCopyTo<ffi::pfvar::pf_pool> for Port {
                 pf_pool.proxy_port[1] = 0;
             }
             Port::Range(start_port, end_port, modifier) => {
-                ensure!(
-                    start_port <= end_port,
-                    ErrorKind::InvalidArgument("Lower port is greater than upper port.")
-                );
+                if start_port > end_port {
+                    return Err(TryCopyToError::InvalidPortRange);
+                }
                 pf_pool.port_op = modifier.into();
                 pf_pool.proxy_port[0] = start_port;
                 pf_pool.proxy_port[1] = end_port;

--- a/src/rule/uid.rs
+++ b/src/rule/uid.rs
@@ -9,7 +9,7 @@
 use crate::{
     conversion::TryCopyTo,
     ffi::pfvar::{self, pf_rule_uid},
-    Result,
+    TryCopyToResult,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -41,7 +41,9 @@ impl<T: Into<Id>> From<T> for Uid {
 }
 
 impl TryCopyTo<pf_rule_uid> for Uid {
-    fn try_copy_to(&self, pf_rule_uid: &mut pf_rule_uid) -> Result<()> {
+    type Result = TryCopyToResult<()>;
+
+    fn try_copy_to(&self, pf_rule_uid: &mut pf_rule_uid) -> Self::Result {
         match self.0 {
             Id::Any => {
                 pf_rule_uid.uid[0] = 0;

--- a/tests/anchors.rs
+++ b/tests/anchors.rs
@@ -30,7 +30,7 @@ test!(add_filter_anchor {
 
     assert_matches!(
         pf.add_anchor(&anchor_name, pfctl::AnchorKind::Filter),
-        Err(pfctl::Error(pfctl::ErrorKind::StateAlreadyActive, _))
+        Err(pfctl::Error::StateAlreadyActive(_))
     );
     assert_matches!(pf.try_add_anchor(&anchor_name, pfctl::AnchorKind::Filter), Ok(()));
 });
@@ -47,7 +47,7 @@ test!(remove_filter_anchor {
 
     assert_matches!(
         pf.remove_anchor(&anchor_name, pfctl::AnchorKind::Filter),
-        Err(pfctl::Error(pfctl::ErrorKind::AnchorDoesNotExist, _))
+        Err(pfctl::Error::AnchorDoesNotExist)
     );
     assert_matches!(pf.try_remove_anchor(&anchor_name, pfctl::AnchorKind::Filter), Ok(()));
 });

--- a/tests/enable_disable.rs
+++ b/tests/enable_disable.rs
@@ -17,7 +17,7 @@ test!(enable_pf {
     assert_matches!(pfcli::disable_firewall(), Ok(()));
     assert_matches!(pf.enable(), Ok(()));
     assert_matches!(pfcli::is_enabled(), Ok(true));
-    assert_matches!(pf.enable(), Err(pfctl::Error(pfctl::ErrorKind::StateAlreadyActive, _)));
+    assert_matches!(pf.enable(), Err(pfctl::Error::StateAlreadyActive(_)));
     assert_matches!(pf.try_enable(), Ok(()));
     assert_matches!(pfcli::is_enabled(), Ok(true));
 });
@@ -28,7 +28,7 @@ test!(disable_pf {
     assert_matches!(pfcli::enable_firewall(), Ok(()));
     assert_matches!(pf.disable(), Ok(()));
     assert_matches!(pfcli::is_enabled(), Ok(false));
-    assert_matches!(pf.disable(), Err(pfctl::Error(pfctl::ErrorKind::StateAlreadyActive, _)));
+    assert_matches!(pf.disable(), Err(pfctl::Error::StateAlreadyActive(_)));
     assert_matches!(pf.try_disable(), Ok(()));
     assert_matches!(pfcli::is_enabled(), Ok(false));
 });


### PR DESCRIPTION
Changed `error-chain` to `thiserror`, and updated dependencies.
Maybe you would also want to remove `error-chain` from examples and tests.

Closes #66

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/88)
<!-- Reviewable:end -->
