### PR TITLE
Remove unused import of IdUnaryModifier

### DIFF
--- a/src/rule/gid.rs
+++ b/src/rule/gid.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-pub use super::uid::{Id, IdUnaryModifier};
+pub use super::uid::Id;
 use crate::{
     conversion::TryCopyTo,
     ffi::pfvar::{pf_rule_gid, PF_OP_NONE},


### PR DESCRIPTION
We don't have any CI in this repo yet. So small issues like this easily slip. I'm in the process of adding CI etc. But want to clean up some low hanging fruits asap.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/90)
<!-- Reviewable:end -->
