### PR TITLE
refactor: remove unnecessary `u32` casts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ impl PfCtl {
             .chain_err(|| ErrorKind::InvalidArgument("Invalid anchor name"))?;
         rule.try_copy_to(&mut pfioc_rule.rule)?;
 
-        pfioc_rule.action = ffi::pfvar::PF_CHANGE_ADD_TAIL as u32;
+        pfioc_rule.action = ffi::pfvar::PF_CHANGE_ADD_TAIL;
         ioctl_guard!(ffi::pf_change_rule(self.fd(), &mut pfioc_rule))
     }
 
@@ -270,7 +270,7 @@ impl PfCtl {
         pfioc_rule.ticket = utils::get_ticket(self.fd(), anchor, AnchorKind::Redirect)?;
 
         // append rule
-        pfioc_rule.action = ffi::pfvar::PF_CHANGE_ADD_TAIL as u32;
+        pfioc_rule.action = ffi::pfvar::PF_CHANGE_ADD_TAIL;
         ioctl_guard!(ffi::pf_change_rule(self.fd(), &mut pfioc_rule))
     }
 
@@ -351,7 +351,7 @@ impl PfCtl {
         let mut pfioc_rule = unsafe { mem::zeroed::<ffi::pfvar::pfioc_rule>() };
         pfioc_rule.rule.action = kind.into();
         ioctl_guard!(ffi::pf_get_rules(self.fd(), &mut pfioc_rule))?;
-        pfioc_rule.action = ffi::pfvar::PF_GET_NONE as u32;
+        pfioc_rule.action = ffi::pfvar::PF_GET_NONE;
         for i in 0..pfioc_rule.nr {
             pfioc_rule.nr = i;
             ioctl_guard!(ffi::pf_get_rule(self.fd(), &mut pfioc_rule))?;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -116,7 +116,7 @@ impl Transaction {
     fn add_filter_rule(fd: RawFd, anchor: &str, rule: &FilterRule, ticket: u32) -> Result<()> {
         // prepare pfioc_rule
         let mut pfioc_rule = unsafe { mem::zeroed::<ffi::pfvar::pfioc_rule>() };
-        pfioc_rule.action = ffi::pfvar::PF_CHANGE_NONE as u32;
+        pfioc_rule.action = ffi::pfvar::PF_CHANGE_NONE;
         anchor
             .try_copy_to(&mut pfioc_rule.anchor[..])
             .chain_err(|| ErrorKind::InvalidArgument("Invalid anchor name"))?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,7 +46,7 @@ pub fn get_pool_ticket(fd: RawFd) -> Result<u32> {
 
 pub fn get_ticket(fd: RawFd, anchor: &str, kind: AnchorKind) -> Result<u32> {
     let mut pfioc_rule = unsafe { mem::zeroed::<ffi::pfvar::pfioc_rule>() };
-    pfioc_rule.action = ffi::pfvar::PF_CHANGE_GET_TICKET as u32;
+    pfioc_rule.action = ffi::pfvar::PF_CHANGE_GET_TICKET;
     pfioc_rule.rule.action = kind.into();
     anchor
         .try_copy_to(&mut pfioc_rule.anchor[..])


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/91)
<!-- Reviewable:end -->
