### PR TITLE
Upgrade ipnetwork to 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ error-chain = "0.12"
 ioctl-sys = "0.6.0"
 libc = "0.2.29"
 derive_builder = "0.9"
-ipnetwork = "0.16"
+ipnetwork = "0.20.0"
 
 [dev-dependencies]
 assert_matches = "1.1.0"


### PR DESCRIPTION
`ipnetwork` has not seen any relaese in a long time, yet we use an old version. Just upgrading to the latest even if there is nothing in there we really need

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/92)
<!-- Reviewable:end -->
