### PR TITLE
Build in CI with --locked

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,7 @@ jobs:
           default: true
 
       - name: Build
-        run: cargo build --all-targets
+        run: cargo build --all-targets --locked
 
       - name: Test
         # Since the tests modify global state (the system firewall) they cannot run in parallel.


### PR DESCRIPTION
Small follow-up to #89 

This ensures the Cargo.lock file stays up to date. If someone add or change a dependency in a way that require lockfile changes, the CI should fail. When the lockfile is versioned it has to stay up to date