### PR TITLE
Upgrade ioctl-sys to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,9 +169,9 @@ checksum = "3c9826188e666f2ed92071d2dadef6edc430b11b158b5b2b3f4babbcc891eaaa"
 
 [[package]]
 name = "ioctl-sys"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c429fffa658f288669529fc26565f728489a2e39bc7b24a428aaaf51355182e"
+checksum = "8bd11f3a29434026f5ff98c730b668ba74b1033637b8817940b54d040696133c"
 
 [[package]]
 name = "ipnetwork"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "mullvad/pfctl-rs" }
 
 [dependencies]
 error-chain = "0.12.4"
-ioctl-sys = "0.6.0"
+ioctl-sys = "0.8.0"
 libc = "0.2.29"
 derive_builder = "0.9"
 ipnetwork = "0.20.0"


### PR DESCRIPTION
ioctl-sys has no dependencies, so this does not affect the dependency tree more than this direct dependency. There were no direct needs to upgrade except that it's nice to just go with the latest from time to time.

ioctl-sys added support for OpenBSD. We have not tried this crate on OpenBSD, but since that OS has PF, this *might* make this crate work on OpenBSD.

I did read the actual diff between `0.6.0` and `0.8.0`. Not much noteworthy except the support for OpenBSD.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/100)
<!-- Reviewable:end -->
