### PR TITLE
Set Rust edition to 2021

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
+        # Keep MSRV in sync with rust-version in Cargo.toml as much as possible.
         rust: [stable, beta, nightly, 1.62.0]
     runs-on: macos-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 * Upgrade `ipnetwork` dependency from 0.16 to 0.20. This is a breaking change since
   `ipnetwork` is part of the public API.
+* Upgrade crate to Rust 2021 edition.
 
 ### Removed
 * Remove `PoolAddrList::to_palist` from the public API. It should never have been exposed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/mullvad/pfctl-rs"
 readme = "README.md"
 keywords = ["pf", "firewall", "macos", "packet", "filter"]
 categories = ["network-programming", "os", "os::macos-apis", "api-bindings"]
-edition = "2018"
+edition = "2021"
 
 [badges]
 travis-ci = { repository = "mullvad/pfctl-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["pf", "firewall", "macos", "packet", "filter"]
 categories = ["network-programming", "os", "os::macos-apis", "api-bindings"]
 edition = "2021"
+rust-version = "1.62.0"
 
 [badges]
 travis-ci = { repository = "mullvad/pfctl-rs" }


### PR DESCRIPTION
No immediate need for the new edition. But no reason to leave it at 2018. Allows more modern Rust code and can be helpful in certain cases. Uses newer dependency resolver, brings more stuff into the prelude and more.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/101)
<!-- Reviewable:end -->
