### PR TITLE
Stop using error_chain! in examples

### DIFF
--- a/examples/add_anchor.rs
+++ b/examples/add_anchor.rs
@@ -6,25 +6,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[macro_use]
-extern crate error_chain;
-
 use pfctl::PfCtl;
 use std::env;
 
-error_chain! {}
-quick_main!(run);
-
-fn run() -> Result<()> {
-    let mut pf = PfCtl::new().chain_err(|| "Unable to connect to PF")?;
+fn main() {
+    let mut pf = PfCtl::new().expect("Unable to connect to PF");
 
     for anchor_name in env::args().skip(1) {
         pf.try_add_anchor(&anchor_name, pfctl::AnchorKind::Filter)
-            .chain_err(|| "Unable to add filter anchor")?;
+            .expect("Unable to add filter anchor");
         pf.try_add_anchor(&anchor_name, pfctl::AnchorKind::Redirect)
-            .chain_err(|| "Unable to add redirect anchor")?;
+            .expect("Unable to add redirect anchor");
 
         println!("Added {} as both a redirect and filter anchor", anchor_name);
     }
-    Ok(())
 }

--- a/examples/add_rules.rs
+++ b/examples/add_rules.rs
@@ -6,23 +6,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[macro_use]
-extern crate error_chain;
-
 use pfctl::{ipnetwork, FilterRuleBuilder, PfCtl, RedirectRuleBuilder};
 use std::net::Ipv4Addr;
 
-error_chain! {}
-quick_main!(run);
-
 static ANCHOR_NAME: &str = "test.anchor";
 
-fn run() -> Result<()> {
-    let mut pf = PfCtl::new().chain_err(|| "Unable to connect to PF")?;
+fn main() {
+    let mut pf = PfCtl::new().expect("Unable to connect to PF");
     pf.try_add_anchor(ANCHOR_NAME, pfctl::AnchorKind::Filter)
-        .chain_err(|| "Unable to add test filter anchor")?;
+        .expect("Unable to add test filter anchor");
     pf.try_add_anchor(ANCHOR_NAME, pfctl::AnchorKind::Redirect)
-        .chain_err(|| "Unable to add test redirect anchor")?;
+        .expect("Unable to add test redirect anchor");
 
     // Create the firewall rule instances
     let pass_all_rule = FilterRuleBuilder::default()
@@ -95,26 +89,25 @@ fn run() -> Result<()> {
 
     // Add the rules to the test anchor
     pf.add_rule(ANCHOR_NAME, &pass_all_rule)
-        .chain_err(|| "Unable to add rule")?;
+        .expect("Unable to add rule");
     pf.add_rule(ANCHOR_NAME, &pass_all_ipv4_quick_rule)
-        .chain_err(|| "Unable to add rule")?;
+        .expect("Unable to add rule");
     pf.add_rule(ANCHOR_NAME, &pass_all_ipv6_on_utun0_rule)
-        .chain_err(|| "Unable to add rule")?;
+        .expect("Unable to add rule");
     pf.add_rule(ANCHOR_NAME, &block_a_private_net_rule)
-        .chain_err(|| "Unable to add rule")?;
+        .expect("Unable to add rule");
     pf.add_rule(ANCHOR_NAME, &pass_all_icmp_echo_req)
-        .chain_err(|| "Unable to add rule")?;
+        .expect("Unable to add rule");
     pf.add_rule(ANCHOR_NAME, &pass_all_icmp_port_unreach)
-        .chain_err(|| "Unable to add rule")?;
+        .expect("Unable to add rule");
     pf.add_rule(ANCHOR_NAME, &pass_all_icmp_timex_transit)
-        .chain_err(|| "Unable to add rule")?;
+        .expect("Unable to add rule");
     pf.add_rule(ANCHOR_NAME, &pass_all_icmp_timex_reassembly)
-        .chain_err(|| "Unable to add rule")?;
+        .expect("Unable to add rule");
     pf.add_redirect_rule(ANCHOR_NAME, &redirect_incoming_tcp_from_port_3000_to_4000)
-        .chain_err(|| "Unable to add redirect rule")?;
+        .expect("Unable to add redirect rule");
 
     println!("Added a bunch of rules to the {} anchor.", ANCHOR_NAME);
     println!("Run this command to remove them:");
     println!("sudo pfctl -a {} -F all", ANCHOR_NAME);
-    Ok(())
 }

--- a/examples/enable.rs
+++ b/examples/enable.rs
@@ -6,23 +6,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[macro_use]
-extern crate error_chain;
-
 use pfctl::PfCtl;
 
-error_chain! {}
-quick_main!(run);
-
-fn run() -> Result<()> {
+fn main() {
     // Create a handle to the firewall. This opens the file /dev/pf and requires root.
-    let mut pf = PfCtl::new().chain_err(|| "Unable to connect to PF")?;
+    let mut pf = PfCtl::new().expect("Unable to connect to PF");
 
     // Try to enable the firewall. Equivalent to the CLI command "pfctl -e".
     match pf.enable() {
         Ok(_) => println!("Enabled PF"),
         Err(pfctl::Error(pfctl::ErrorKind::StateAlreadyActive, _)) => (),
-        err => err.chain_err(|| "Unable to enable PF")?,
+        err => err.expect("Unable to enable PF"),
     }
-    Ok(())
 }

--- a/examples/flush_rules.rs
+++ b/examples/flush_rules.rs
@@ -13,13 +13,12 @@ fn main() {
     let mut pf = PfCtl::new().expect("Unable to connect to PF");
 
     for anchor_name in env::args().skip(1) {
-        match pf.flush_rules(&anchor_name, pfctl::RulesetKind::Filter) {
-            Ok(_) => println!("Flushed filter rules under anchor {}", anchor_name),
-            err => err.expect("Unable to flush filter rules"),
-        }
-        match pf.flush_rules(&anchor_name, pfctl::RulesetKind::Redirect) {
-            Ok(_) => println!("Flushed redirect rules under anchor {}", anchor_name),
-            err => err.expect("Unable to flush redirect rules"),
-        }
+        pf.flush_rules(&anchor_name, pfctl::RulesetKind::Filter)
+            .expect("Unable to flush filter rules");
+        println!("Flushed filter rules under anchor {}", anchor_name);
+
+        pf.flush_rules(&anchor_name, pfctl::RulesetKind::Redirect)
+            .expect("Unable to flush redirect rules");
+        println!("Flushed redirect rules under anchor {}", anchor_name);
     }
 }

--- a/examples/flush_rules.rs
+++ b/examples/flush_rules.rs
@@ -6,27 +6,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[macro_use]
-extern crate error_chain;
-
 use pfctl::PfCtl;
 use std::env;
 
-error_chain! {}
-quick_main!(run);
-
-fn run() -> Result<()> {
-    let mut pf = PfCtl::new().chain_err(|| "Unable to connect to PF")?;
+fn main() {
+    let mut pf = PfCtl::new().expect("Unable to connect to PF");
 
     for anchor_name in env::args().skip(1) {
         match pf.flush_rules(&anchor_name, pfctl::RulesetKind::Filter) {
             Ok(_) => println!("Flushed filter rules under anchor {}", anchor_name),
-            err => err.chain_err(|| "Unable to flush filter rules")?,
+            err => err.expect("Unable to flush filter rules"),
         }
         match pf.flush_rules(&anchor_name, pfctl::RulesetKind::Redirect) {
             Ok(_) => println!("Flushed redirect rules under anchor {}", anchor_name),
-            err => err.chain_err(|| "Unable to flush redirect rules")?,
+            err => err.expect("Unable to flush redirect rules"),
         }
     }
-    Ok(())
 }

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -6,23 +6,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[macro_use]
-extern crate error_chain;
-
 use pfctl::PfCtl;
 use std::net::Ipv4Addr;
 
-error_chain! {}
-quick_main!(run);
-
 static ANCHOR_NAME: &str = "test.anchor";
 
-fn run() -> Result<()> {
-    let mut pf = PfCtl::new().chain_err(|| "Unable to connect to PF")?;
+fn main() {
+    let mut pf = PfCtl::new().expect("Unable to connect to PF");
     pf.try_add_anchor(ANCHOR_NAME, pfctl::AnchorKind::Filter)
-        .chain_err(|| "Unable to add test filter anchor")?;
+        .expect("Unable to add test filter anchor");
     pf.try_add_anchor(ANCHOR_NAME, pfctl::AnchorKind::Redirect)
-        .chain_err(|| "Unable to add test redirect anchor")?;
+        .expect("Unable to add test redirect anchor");
 
     // Create some firewall rules that we want to set in one atomic transaction.
     let trans_rule1 = pfctl::FilterRuleBuilder::default()
@@ -51,10 +45,9 @@ fn run() -> Result<()> {
     // Execute the transaction. This will OVERWRITE any existing rules under this anchor as it's
     // a set operation, not an add operation.
     pf.set_rules(ANCHOR_NAME, trans_change)
-        .chain_err(|| "Unable to set rules")?;
+        .expect("Unable to set rules");
 
     println!("Added a bunch of rules to the {} anchor.", ANCHOR_NAME);
     println!("Run this command to remove them:");
     println!("sudo pfctl -a {} -F all", ANCHOR_NAME);
-    Ok(())
 }


### PR DESCRIPTION
We want to get rid of `error-chain` as a dependency completely. Some work towards this has been started in #88. However, for now that PR keeps `error-chain` for the examples. I approach the problem from the other direction with this PR: Getting rid of `error-chain` in the examples first. They are simpler and require less nice API surface since they are just example binaries, not a public library API.

Here I opted for simply going with `Result<..., Box<dyn std::error::Error>>`. This has the positive side of being very simple. But with the downside that we don't have an error *chain* in the same way. We lose some of the context we previously had with an error. This might make it slightly harder to track down what failed when examples fail. On the other hand, examples should focus on showcasing how to use the main crate, not how to do ideal error handling. I'm open to discuss alternative solutions. We could replace all `chain_err` with `expect` and have the examples panic instead. In practice it won't make much of a difference since that's basically what returning an error from main does anyway :shrug:. However, that's arguably even more "ugly" error handling than `Box<dyn Error>`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/102)
<!-- Reviewable:end -->
