### PR TITLE
Remove error-chain dependency in tests and test helpers

### DIFF
--- a/tests/anchors.rs
+++ b/tests/anchors.rs
@@ -1,7 +1,4 @@
 #[macro_use]
-extern crate error_chain;
-
-#[macro_use]
 #[allow(dead_code)]
 mod helper;
 
@@ -22,7 +19,7 @@ test!(add_filter_anchor {
 
     assert_matches!(pf.add_anchor(&anchor_name, pfctl::AnchorKind::Filter), Ok(()));
 
-    let anchors = pfcli::get_anchors(None).unwrap();
+    let anchors = pfcli::get_anchors(None);
     assert!(anchors.contains(&anchor_name));
 
     assert_matches!(
@@ -39,7 +36,7 @@ test!(remove_filter_anchor {
     assert_matches!(pf.add_anchor(&anchor_name, pfctl::AnchorKind::Filter), Ok(()));
     assert_matches!(pf.remove_anchor(&anchor_name, pfctl::AnchorKind::Filter), Ok(()));
 
-    let anchors = pfcli::get_anchors(None).unwrap();
+    let anchors = pfcli::get_anchors(None);
     assert!(!anchors.contains(&anchor_name));
 
     assert_matches!(

--- a/tests/enable_disable.rs
+++ b/tests/enable_disable.rs
@@ -1,7 +1,4 @@
 #[macro_use]
-extern crate error_chain;
-
-#[macro_use]
 #[allow(dead_code)]
 mod helper;
 
@@ -14,21 +11,21 @@ fn after_each() {}
 test!(enable_pf {
     let mut pf = pfctl::PfCtl::new().unwrap();
 
-    assert_matches!(pfcli::disable_firewall(), Ok(()));
+    pfcli::disable_firewall();
     assert_matches!(pf.enable(), Ok(()));
-    assert_matches!(pfcli::is_enabled(), Ok(true));
+    assert!(pfcli::is_enabled());
     assert_matches!(pf.enable(), Err(pfctl::Error(pfctl::ErrorKind::StateAlreadyActive, _)));
     assert_matches!(pf.try_enable(), Ok(()));
-    assert_matches!(pfcli::is_enabled(), Ok(true));
+    assert!(pfcli::is_enabled());
 });
 
 test!(disable_pf {
     let mut pf = pfctl::PfCtl::new().unwrap();
 
-    assert_matches!(pfcli::enable_firewall(), Ok(()));
+    pfcli::enable_firewall();
     assert_matches!(pf.disable(), Ok(()));
-    assert_matches!(pfcli::is_enabled(), Ok(false));
+    assert!(!pfcli::is_enabled());
     assert_matches!(pf.disable(), Err(pfctl::Error(pfctl::ErrorKind::StateAlreadyActive, _)));
     assert_matches!(pf.try_disable(), Ok(()));
-    assert_matches!(pfcli::is_enabled(), Ok(false));
+    assert!(!pfcli::is_enabled());
 });

--- a/tests/filter_rules.rs
+++ b/tests/filter_rules.rs
@@ -1,7 +1,4 @@
 #[macro_use]
-extern crate error_chain;
-
-#[macro_use]
 #[allow(dead_code)]
 mod helper;
 
@@ -19,7 +16,7 @@ fn before_each() {
 }
 
 fn after_each() {
-    pfcli::flush_rules(ANCHOR_NAME, pfcli::FlushOptions::Rules).unwrap();
+    pfcli::flush_rules(ANCHOR_NAME, pfcli::FlushOptions::Rules);
     pfctl::PfCtl::new()
         .unwrap()
         .try_remove_anchor(ANCHOR_NAME, pfctl::AnchorKind::Filter)
@@ -33,10 +30,7 @@ test!(drop_all_rule {
         .build()
         .unwrap();
     assert_matches!(pf.add_rule(ANCHOR_NAME, &rule), Ok(()));
-    assert_matches!(
-        pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &["block drop all"]
-    );
+    assert_eq!(pfcli::get_rules(ANCHOR_NAME), &["block drop all"]);
 });
 
 test!(return_all_rule {
@@ -46,9 +40,8 @@ test!(return_all_rule {
         .build()
         .unwrap();
     assert_matches!(pf.add_rule(ANCHOR_NAME, &rule), Ok(()));
-    assert_matches!(
-        pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &["block return all"]
+    assert_eq!(
+        pfcli::get_rules(ANCHOR_NAME), &["block return all"]
     );
 });
 
@@ -60,10 +53,7 @@ test!(drop_by_direction_rule {
         .build()
         .unwrap();
     assert_matches!(pf.add_rule(ANCHOR_NAME, &rule), Ok(()));
-    assert_matches!(
-        pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &["block drop out all"]
-    );
+    assert_eq!(pfcli::get_rules(ANCHOR_NAME), &["block drop out all"]);
 });
 
 test!(drop_quick_rule {
@@ -74,10 +64,7 @@ test!(drop_quick_rule {
         .build()
         .unwrap();
     assert_matches!(pf.add_rule(ANCHOR_NAME, &rule), Ok(()));
-    assert_matches!(
-        pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &["block drop quick all"]
-    );
+    assert_eq!(pfcli::get_rules(ANCHOR_NAME), &["block drop quick all"]);
 });
 
 test!(drop_by_ip_rule {
@@ -90,9 +77,9 @@ test!(drop_by_ip_rule {
         .build()
         .unwrap();
     assert_matches!(pf.add_rule(ANCHOR_NAME, &rule), Ok(()));
-    assert_matches!(
+    assert_eq!(
         pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &["block drop inet proto tcp from 192.168.0.1 to 127.0.0.1"]
+        &["block drop inet proto tcp from 192.168.0.1 to 127.0.0.1"]
     );
 });
 
@@ -106,9 +93,9 @@ test!(drop_by_port_rule {
         .build()
         .unwrap();
     assert_matches!(pf.add_rule(ANCHOR_NAME, &rule), Ok(()));
-    assert_matches!(
+    assert_eq!(
         pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &["block drop proto tcp from any port = 3000 to any port = 8080"]
+        &["block drop proto tcp from any port = 3000 to any port = 8080"]
     );
 });
 
@@ -122,9 +109,9 @@ test!(drop_by_port_range_rule {
         .build()
         .unwrap();
     assert_matches!(pf.add_rule(ANCHOR_NAME, &rule), Ok(()));
-    assert_matches!(
+    assert_eq!(
         pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &["block drop proto tcp from any port 3000:4000 to any port 5000 >< 6000"]
+        &["block drop proto tcp from any port 3000:4000 to any port 5000 >< 6000"]
     );
 });
 
@@ -136,9 +123,9 @@ test!(drop_by_interface_rule {
         .build()
         .unwrap();
     assert_matches!(pf.add_rule(ANCHOR_NAME, &rule), Ok(()));
-    assert_matches!(
+    assert_eq!(
         pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &["block drop on utun0 all"]
+        &["block drop on utun0 all"]
     );
 });
 
@@ -166,9 +153,9 @@ test!(pass_out_route_rule {
     trans.add_change(ANCHOR_NAME, change);
 
     assert_matches!(trans.commit(), Ok(()));
-    assert_matches!(
+    assert_eq!(
         pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &[
+        &[
             "pass out route-to (lo0 127.0.0.1) inet proto udp \
             from 1.2.3.4 to any port = 53 no state"
         ]
@@ -191,9 +178,9 @@ test!(pass_in_reply_to_rule {
     trans.add_change(ANCHOR_NAME, change);
 
     assert_matches!(trans.commit(), Ok(()));
-    assert_matches!(
+    assert_eq!(
         pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &["pass in on lo1 reply-to lo9 inet from 6.7.8.9 to any no state"]
+        &["pass in on lo1 reply-to lo9 inet from 6.7.8.9 to any no state"]
     );
 });
 
@@ -213,11 +200,9 @@ test!(pass_in_dup_to_rule {
     trans.add_change(ANCHOR_NAME, change);
 
     assert_matches!(trans.commit(), Ok(()));
-    assert_matches!(
+    assert_eq!(
         pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &[
-            "pass in on lo1 dup-to (lo8 1.2.3.4) inet from 6.7.8.9 to any no state"
-        ]
+        &["pass in on lo1 dup-to (lo8 1.2.3.4) inet from 6.7.8.9 to any no state"]
     );
 });
 
@@ -228,15 +213,15 @@ test!(flush_filter_rules {
         .build()
         .unwrap();
     assert_matches!(pf.add_rule(ANCHOR_NAME, &rule), Ok(()));
-    assert_matches!(
-        pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v.len() == 1
+    assert_eq!(
+        pfcli::get_rules(ANCHOR_NAME).len(),
+        1
     );
 
     assert_matches!(pf.flush_rules(ANCHOR_NAME, pfctl::RulesetKind::Filter), Ok(()));
-    assert_matches!(
+    assert_eq!(
         pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v.is_empty()
+        &[] as &[&str]
     );
 });
 
@@ -278,12 +263,14 @@ test!(all_state_policies {
     for rule in [rule1, rule2, rule3, rule4].iter() {
         assert_matches!(pf.add_rule(ANCHOR_NAME, rule), Ok(()));
     }
-    assert_matches!(
+    assert_eq!(
         pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &["pass inet from 192.168.1.1 to any no state",
-                            "pass inet proto tcp from 192.168.1.2 to any flags S/FSRA keep state",
-                            "pass inet proto tcp from 192.168.1.3 to any flags any modulate state",
-                            "pass inet proto tcp from 192.168.1.4 to any flags any synproxy state"]
+        &[
+            "pass inet from 192.168.1.1 to any no state",
+            "pass inet proto tcp from 192.168.1.2 to any flags S/FSRA keep state",
+            "pass inet proto tcp from 192.168.1.3 to any flags any modulate state",
+            "pass inet proto tcp from 192.168.1.4 to any flags any synproxy state"
+        ]
     );
 });
 
@@ -299,8 +286,8 @@ test!(logging {
         .build()
         .unwrap();
     assert_matches!(pf.add_rule(ANCHOR_NAME, &rule), Ok(()));
-    assert_matches!(
+    assert_eq!(
         pfcli::get_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &["block drop log (all, user) all"]
+        &["block drop log (all, user) all"]
     );
 });

--- a/tests/helper/pfcli.rs
+++ b/tests/helper/pfcli.rs
@@ -1,101 +1,86 @@
 use std::{process::Command, str};
 
-mod errors {
-    error_chain! {}
-}
-use self::errors::*;
-
 static PF_BIN: &str = "/sbin/pfctl";
 
-pub fn is_enabled() -> Result<bool> {
+pub fn is_enabled() -> bool {
     let output = get_command()
         .arg("-s")
         .arg("info")
         .output()
-        .chain_err(|| "Failed to run pfctl")?;
-    let str = str_from_stdout(&output.stdout)?;
+        .expect("Failed to run pfctl");
+    let str = str_from_stdout(&output.stdout);
 
     if str.starts_with("Status: Enabled") {
-        Ok(true)
+        true
     } else if str.starts_with("Status: Disabled") {
-        Ok(false)
+        false
     } else {
-        bail!("Invalid response.");
+        panic!("Invalid response.");
     }
 }
 
-pub fn enable_firewall() -> Result<()> {
+pub fn enable_firewall() {
     let output = get_command()
         .arg("-e")
         .output()
-        .chain_err(|| "Failed to run pfctl")?;
+        .expect("Failed to run pfctl");
 
     // pfctl outputs to stderr for that command
-    let stderr = str_from_stdout(&output.stderr)?;
-
-    ensure!(
-        stderr.contains("pfctl: pf already enabled") || stderr.contains("pf enabled"),
-        "Invalid response."
-    );
-    Ok(())
+    let stderr = str_from_stdout(&output.stderr);
+    assert!(stderr.contains("pfctl: pf already enabled") || stderr.contains("pf enabled"));
 }
 
-pub fn disable_firewall() -> Result<()> {
+pub fn disable_firewall() {
     let output = get_command()
         .arg("-d")
         .output()
-        .chain_err(|| "Failed to run pfctl")?;
+        .expect("Failed to run pfctl");
 
     // pfctl outputs to stderr for that command
-    let stderr = str_from_stdout(&output.stderr)?;
-
-    ensure!(
-        stderr.contains("pfctl: pf not enabled") || stderr.contains("pf disabled"),
-        "Invalid response."
-    );
-    Ok(())
+    let stderr = str_from_stdout(&output.stderr);
+    assert!(stderr.contains("pfctl: pf not enabled") || stderr.contains("pf disabled"));
 }
 
-fn get_rules_internal(anchor_name: &str, param_kind: &str) -> Result<Vec<String>> {
+fn get_rules_internal(anchor_name: &str, param_kind: &str) -> Vec<String> {
     let output = get_command()
         .arg("-a")
         .arg(anchor_name)
         .arg("-s")
         .arg(param_kind)
         .output()
-        .chain_err(|| "Failed to run pfctl")?;
-    let output = str_from_stdout(&output.stdout)?;
+        .expect("Failed to run pfctl");
+    let output = str_from_stdout(&output.stdout);
     let rules = output.lines().map(|x| x.trim().to_owned()).collect();
-    Ok(rules)
+    rules
 }
 
 /// List anchors.
 /// Pass parent anchor's name to obtain nested anchors.
 /// Otherwise, pass None to obtain anchors from main ruleset.
-pub fn get_anchors(parent_anchor: Option<&str>) -> Result<Vec<String>> {
+pub fn get_anchors(parent_anchor: Option<&str>) -> Vec<String> {
     get_rules_internal(parent_anchor.unwrap_or("*"), "Anchors")
 }
 
 /// Get filter rules in anchor
-pub fn get_rules(anchor_name: &str) -> Result<Vec<String>> {
+pub fn get_rules(anchor_name: &str) -> Vec<String> {
     get_rules_internal(anchor_name, "rules")
 }
 
 /// Get nat rules in anchor
-pub fn get_nat_rules(anchor_name: &str) -> Result<Vec<String>> {
+pub fn get_nat_rules(anchor_name: &str) -> Vec<String> {
     get_rules_internal(anchor_name, "nat")
 }
 
 /// Get global table of states
-pub fn get_all_states() -> Result<Vec<String>> {
+pub fn get_all_states() -> Vec<String> {
     let output = get_command()
         .arg("-s")
         .arg("states")
         .output()
-        .chain_err(|| "Failed to run pfctl")?;
-    let output = str_from_stdout(&output.stdout)?;
+        .expect("Failed to run pfctl");
+    let output = str_from_stdout(&output.stdout);
     let states = output.lines().map(|x| x.trim().to_owned()).collect();
-    Ok(states)
+    states
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -117,7 +102,7 @@ impl From<FlushOptions> for &'static str {
     }
 }
 
-pub fn flush_rules(anchor_name: &str, options: FlushOptions) -> Result<()> {
+pub fn flush_rules(anchor_name: &str, options: FlushOptions) {
     let flush_arg: &'static str = options.into();
     let output = get_command()
         .arg("-a")
@@ -125,30 +110,26 @@ pub fn flush_rules(anchor_name: &str, options: FlushOptions) -> Result<()> {
         .arg("-F")
         .arg(flush_arg)
         .output()
-        .chain_err(|| "Failed to run pfctl")?;
-    let output = str_from_stdout(&output.stderr)?;
+        .expect("Failed to run pfctl");
+    let output = str_from_stdout(&output.stderr);
 
     if options == FlushOptions::All || options == FlushOptions::Rules {
-        ensure!(output.contains("rules cleared"), "Invalid response.");
+        assert!(output.contains("rules cleared"), "Invalid response.");
     }
-
     if options == FlushOptions::All || options == FlushOptions::Nat {
-        ensure!(output.contains("nat cleared"), "Invalid response.");
+        assert!(output.contains("nat cleared"), "Invalid response.");
     }
-
     if options == FlushOptions::States {
-        ensure!(output.contains("states cleared"), "Invalid response.");
+        assert!(output.contains("states cleared"), "Invalid response.");
     }
-
-    Ok(())
 }
 
 fn get_command() -> Command {
     Command::new(PF_BIN)
 }
 
-fn str_from_stdout(stdout: &[u8]) -> Result<String> {
+fn str_from_stdout(stdout: &[u8]) -> String {
     str::from_utf8(stdout)
         .map(|v| v.trim().to_owned())
-        .chain_err(|| "Failed to convert buffer to string.")
+        .expect("pfctl output not valid UTF-8")
 }

--- a/tests/redirect_rules.rs
+++ b/tests/redirect_rules.rs
@@ -1,7 +1,4 @@
 #[macro_use]
-extern crate error_chain;
-
-#[macro_use]
 #[allow(dead_code)]
 mod helper;
 
@@ -36,7 +33,7 @@ fn before_each() {
 }
 
 fn after_each() {
-    pfcli::flush_rules(ANCHOR_NAME, pfcli::FlushOptions::Nat).unwrap();
+    pfcli::flush_rules(ANCHOR_NAME, pfcli::FlushOptions::Nat);
     pfctl::PfCtl::new()
         .unwrap()
         .try_remove_anchor(ANCHOR_NAME, pfctl::AnchorKind::Redirect)
@@ -48,15 +45,12 @@ test!(flush_redirect_rules {
     let test_rules = [redirect_rule_ipv4(), redirect_rule_ipv6()];
     for rule in test_rules.iter() {
         assert_matches!(pf.add_redirect_rule(ANCHOR_NAME, rule), Ok(()));
-        assert_matches!(
-            pfcli::get_nat_rules(ANCHOR_NAME),
-            Ok(ref v) if v.len() == 1
-        );
+        assert_eq!(pfcli::get_nat_rules(ANCHOR_NAME).len(), 1);
 
         assert_matches!(pf.flush_rules(ANCHOR_NAME, pfctl::RulesetKind::Redirect), Ok(()));
-        assert_matches!(
+        assert_eq!(
             pfcli::get_nat_rules(ANCHOR_NAME),
-            Ok(ref v) if v.is_empty()
+            &[] as &[&str]
         );
     }
 });
@@ -65,9 +59,9 @@ test!(add_redirect_rule_ipv4 {
     let mut pf = pfctl::PfCtl::new().unwrap();
     let rule = redirect_rule_ipv4();
     assert_matches!(pf.add_redirect_rule(ANCHOR_NAME, &rule), Ok(()));
-    assert_matches!(
+    assert_eq!(
         pfcli::get_nat_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &["rdr inet from any to 127.0.0.1 port = 3000 -> 127.0.0.1 port 4000"]
+        &["rdr inet from any to 127.0.0.1 port = 3000 -> 127.0.0.1 port 4000"]
     );
 });
 
@@ -75,9 +69,9 @@ test!(add_redirect_rule_ipv6 {
     let mut pf = pfctl::PfCtl::new().unwrap();
     let rule = redirect_rule_ipv6();
     assert_matches!(pf.add_redirect_rule(ANCHOR_NAME, &rule), Ok(()));
-    assert_matches!(
+    assert_eq!(
         pfcli::get_nat_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &["rdr inet6 from any to ::1 port = 3000 -> ::1 port 4000"]
+        &["rdr inet6 from any to ::1 port = 3000 -> ::1 port 4000"]
     );
 });
 
@@ -92,8 +86,8 @@ test!(add_redirect_rule_on_interface {
         .build()
         .unwrap();
     assert_matches!(pf.add_redirect_rule(ANCHOR_NAME, &rule), Ok(()));
-    assert_matches!(
+    assert_eq!(
         pfcli::get_nat_rules(ANCHOR_NAME),
-        Ok(ref v) if v == &["rdr log on lo0 inet from 1.2.3.4 to any -> any port 1237"]
+        &["rdr log on lo0 inet from 1.2.3.4 to any -> any port 1237"]
     );
 });

--- a/tests/states.rs
+++ b/tests/states.rs
@@ -1,7 +1,4 @@
 #[macro_use]
-extern crate error_chain;
-
-#[macro_use]
 #[allow(dead_code)]
 mod helper;
 
@@ -42,7 +39,7 @@ fn rule_builder(destination: SocketAddr) -> pfctl::FilterRule {
 }
 
 fn before_each() {
-    pfcli::enable_firewall().unwrap();
+    pfcli::enable_firewall();
     pfctl::PfCtl::new()
         .unwrap()
         .try_add_anchor(ANCHOR_NAME, pfctl::AnchorKind::Filter)
@@ -50,8 +47,8 @@ fn before_each() {
 }
 
 fn after_each() {
-    pfcli::flush_rules(ANCHOR_NAME, pfcli::FlushOptions::Rules).unwrap();
-    pfcli::flush_rules(ANCHOR_NAME, pfcli::FlushOptions::States).unwrap();
+    pfcli::flush_rules(ANCHOR_NAME, pfcli::FlushOptions::Rules);
+    pfcli::flush_rules(ANCHOR_NAME, pfcli::FlushOptions::States);
     pfctl::PfCtl::new()
         .unwrap()
         .try_remove_anchor(ANCHOR_NAME, pfctl::AnchorKind::Filter)
@@ -72,15 +69,9 @@ test!(reset_ipv4_states_by_anchor {
         "ALL udp 127.0.0.1:1337 <- 127.0.0.1:1338       NO_TRAFFIC:SINGLE"
     ];
 
-    assert_matches!(
-        pfcli::get_all_states(),
-        Ok(ref v) if contains_subset(v, &expected_states)
-    );
+    assert!(contains_subset(&pfcli::get_all_states(), &expected_states));
     assert_matches!(pf.clear_states(ANCHOR_NAME, pfctl::AnchorKind::Filter), Ok(2));
-    assert_matches!(
-        pfcli::get_all_states(),
-        Ok(ref v) if not_contains_subset(v, &expected_states)
-    );
+    assert!(not_contains_subset(&pfcli::get_all_states(), &expected_states));
 });
 
 test!(reset_ipv6_states_by_anchor {
@@ -97,13 +88,7 @@ test!(reset_ipv6_states_by_anchor {
         "ALL udp ::1[1337] <- ::1[1338]       NO_TRAFFIC:SINGLE"
     ];
 
-    assert_matches!(
-        pfcli::get_all_states(),
-        Ok(ref v) if contains_subset(v, &expected_states)
-    );
+    assert!(contains_subset(&pfcli::get_all_states(), &expected_states));
     assert_matches!(pf.clear_states(ANCHOR_NAME, pfctl::AnchorKind::Filter), Ok(2));
-    assert_matches!(
-        pfcli::get_all_states(),
-        Ok(ref v) if not_contains_subset(v, &expected_states)
-    );
+    assert!(not_contains_subset(&pfcli::get_all_states(), &expected_states));
 });

--- a/tests/transaction.rs
+++ b/tests/transaction.rs
@@ -1,7 +1,4 @@
 #[macro_use]
-extern crate error_chain;
-
-#[macro_use]
 #[allow(dead_code)]
 mod helper;
 
@@ -28,8 +25,8 @@ fn before_each() {
 
 fn after_each() {
     for anchor_name in ANCHORS.iter() {
-        pfcli::flush_rules(anchor_name, pfcli::FlushOptions::Rules).unwrap();
-        pfcli::flush_rules(anchor_name, pfcli::FlushOptions::Nat).unwrap();
+        pfcli::flush_rules(anchor_name, pfcli::FlushOptions::Rules);
+        pfcli::flush_rules(anchor_name, pfcli::FlushOptions::Nat);
         pfctl::PfCtl::new()
             .unwrap()
             .try_remove_anchor(anchor_name, pfctl::AnchorKind::Filter)
@@ -90,9 +87,9 @@ fn get_marker_redirect_rule() -> pfctl::RedirectRule {
 }
 
 fn verify_filter_rules(anchor: &str) {
-    assert_matches!(
+    assert_eq!(
         pfcli::get_rules(anchor),
-        Ok(ref rules) if rules == &vec![
+        &[
             "pass inet from any to 1.2.3.4 no state",
             "pass inet from any to 9.8.7.6 no state",
         ]
@@ -100,9 +97,9 @@ fn verify_filter_rules(anchor: &str) {
 }
 
 fn verify_redirect_rules(anchor: &str) {
-    assert_matches!(
+    assert_eq!(
         pfcli::get_nat_rules(anchor),
-        Ok(ref rules) if rules == &vec![
+        &[
             "rdr inet from 1.2.3.4 to any port = 3000 -> any port 4000",
             "rdr inet from 1.2.3.4 to any port = 5000 -> any port 6000",
         ]
@@ -110,16 +107,13 @@ fn verify_redirect_rules(anchor: &str) {
 }
 
 fn verify_filter_marker(anchor: &str) {
-    assert_matches!(
-        pfcli::get_rules(anchor),
-        Ok(ref rules) if rules == &vec!["pass all no state"]
-    );
+    assert_eq!(pfcli::get_rules(anchor), &["pass all no state"]);
 }
 
 fn verify_redirect_marker(anchor: &str) {
-    assert_matches!(
+    assert_eq!(
         pfcli::get_nat_rules(anchor),
-        Ok(ref rules) if rules == &vec!["rdr from any to any port = 1337 -> any port 1338"]
+        &["rdr from any to any port = 1337 -> any port 1338"]
     );
 }
 


### PR DESCRIPTION
Follow up to #102. I realized we also used `error-chain` in tests :facepalm:. So a step in the direction of removing error-chain completely is to stop using it in tests. I just replaced most error handling with `expect`, since expect/unwrap is all we did with the errors we had anyway.

Since a lot of the test helper methods became infallible, sadly virtually every test was affected, due to them using the test helpers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/104)
<!-- Reviewable:end -->
