### PR TITLE
Simplify some error handling

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # Keep MSRV in sync with rust-version in Cargo.toml as much as possible.
-        rust: [stable, beta, nightly, 1.62.0]
+        rust: [stable, beta, nightly, 1.69.0]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 * Upgrade `ipnetwork` dependency from 0.16 to 0.20. This is a breaking change since
   `ipnetwork` is part of the public API.
 * Upgrade crate to Rust 2021 edition.
+* MSRV bumped to 1.69 due to use of `CStr::from_bytes_until_nul`.
 
 ### Removed
 * Remove `PoolAddrList::to_palist` from the public API. It should never have been exposed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["pf", "firewall", "macos", "packet", "filter"]
 categories = ["network-programming", "os", "os::macos-apis", "api-bindings"]
 edition = "2021"
-rust-version = "1.62.0"
+rust-version = "1.69.0"
 
 [badges]
 travis-ci = { repository = "mullvad/pfctl-rs" }

--- a/src/rule/gid.rs
+++ b/src/rule/gid.rs
@@ -8,9 +8,8 @@
 
 pub use super::uid::Id;
 use crate::{
-    conversion::TryCopyTo,
+    conversion::CopyTo,
     ffi::pfvar::{pf_rule_gid, PF_OP_NONE},
-    Result,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -28,8 +27,8 @@ impl<T: Into<Id>> From<T> for Gid {
     }
 }
 
-impl TryCopyTo<pf_rule_gid> for Gid {
-    fn try_copy_to(&self, pf_rule_gid: &mut pf_rule_gid) -> Result<()> {
+impl CopyTo<pf_rule_gid> for Gid {
+    fn copy_to(&self, pf_rule_gid: &mut pf_rule_gid) {
         match self.0 {
             Id::Any => {
                 pf_rule_gid.gid[0] = 0;
@@ -47,6 +46,5 @@ impl TryCopyTo<pf_rule_gid> for Gid {
                 pf_rule_gid.op = modifier.into();
             }
         }
-        Ok(())
     }
 }

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -155,8 +155,8 @@ impl TryCopyTo<ffi::pfvar::pf_rule> for FilterRule {
         self.from.try_copy_to(&mut pf_rule.src)?;
         self.to.try_copy_to(&mut pf_rule.dst)?;
         self.label.try_copy_to(&mut pf_rule.label)?;
-        self.user.try_copy_to(&mut pf_rule.uid)?;
-        self.group.try_copy_to(&mut pf_rule.gid)?;
+        self.user.copy_to(&mut pf_rule.uid);
+        self.group.copy_to(&mut pf_rule.gid);
         if let Some(icmp_type) = self.icmp_type {
             icmp_type.copy_to(pf_rule);
         }
@@ -232,8 +232,8 @@ impl TryCopyTo<ffi::pfvar::pf_rule> for RedirectRule {
         self.from.try_copy_to(&mut pf_rule.src)?;
         self.to.try_copy_to(&mut pf_rule.dst)?;
         self.label.try_copy_to(&mut pf_rule.label)?;
-        self.user.try_copy_to(&mut pf_rule.uid)?;
-        self.group.try_copy_to(&mut pf_rule.gid)?;
+        self.user.copy_to(&mut pf_rule.uid);
+        self.group.copy_to(&mut pf_rule.gid);
 
         Ok(())
     }

--- a/src/rule/uid.rs
+++ b/src/rule/uid.rs
@@ -7,9 +7,8 @@
 // except according to those terms.
 
 use crate::{
-    conversion::TryCopyTo,
+    conversion::CopyTo,
     ffi::pfvar::{self, pf_rule_uid},
-    Result,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -40,8 +39,8 @@ impl<T: Into<Id>> From<T> for Uid {
     }
 }
 
-impl TryCopyTo<pf_rule_uid> for Uid {
-    fn try_copy_to(&self, pf_rule_uid: &mut pf_rule_uid) -> Result<()> {
+impl CopyTo<pf_rule_uid> for Uid {
+    fn copy_to(&self, pf_rule_uid: &mut pf_rule_uid) {
         match self.0 {
             Id::Any => {
                 pf_rule_uid.uid[0] = 0;
@@ -59,7 +58,6 @@ impl TryCopyTo<pf_rule_uid> for Uid {
                 pf_rule_uid.op = modifier.into();
             }
         }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
This is in preparation of ditching `error-chain`. We had pretty tangled errors. Lots of our own errors are just stringly typed errors (`ensure!` kind of stuff).

This PR just massage away some errors.

* Types that implemented `TryCopyTo` but actually had no code path leading to an error was changed into implementations of the infallible `CopyTo`
* The internal `compare_cstr_safe` was changed to panic instead of returning an error. This because it only deals with parsing C strings returned by the system. Since the system should return C strings, it's something really bad going on with the system if they don't null-terminate their strings. I regard this as a case for panic rather than user error handling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/105)
<!-- Reviewable:end -->
