### PR TITLE
Add connection state methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 * **Security**: in case of vulnerabilities.
 
 ## [unreleased]
+### Added
+- Add function for listing all states created by PF anchor rules.
+- Add function for removing individual states created by PF anchor rules.
+
 ### Changed
 * Upgrade `ipnetwork` dependency from 0.16 to 0.20. This is a breaking change since
   `ipnetwork` is part of the public API.

--- a/src/rule/direction.rs
+++ b/src/rule/direction.rs
@@ -6,23 +6,33 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::ffi;
+use crate::{ffi, Error, ErrorInternal, Result};
 
 /// Enum describing matching of rule towards packet flow direction.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
 pub enum Direction {
     #[default]
-    Any,
-    In,
-    Out,
+    Any = ffi::pfvar::PF_INOUT as u8,
+    In = ffi::pfvar::PF_IN as u8,
+    Out = ffi::pfvar::PF_OUT as u8,
 }
 
 impl From<Direction> for u8 {
     fn from(direction: Direction) -> Self {
+        direction as u8
+    }
+}
+
+impl TryFrom<u8> for Direction {
+    type Error = crate::Error;
+
+    fn try_from(direction: u8) -> Result<Self> {
         match direction {
-            Direction::Any => ffi::pfvar::PF_INOUT as u8,
-            Direction::In => ffi::pfvar::PF_IN as u8,
-            Direction::Out => ffi::pfvar::PF_OUT as u8,
+            v if v == Direction::Any as u8 => Ok(Direction::Any),
+            v if v == Direction::In as u8 => Ok(Direction::In),
+            v if v == Direction::Out as u8 => Ok(Direction::Out),
+            other => Err(Error::from(ErrorInternal::InvalidDirection(other))),
         }
     }
 }

--- a/src/rule/proto.rs
+++ b/src/rule/proto.rs
@@ -6,14 +6,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::{Error, ErrorInternal, Result};
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
 pub enum Proto {
     #[default]
-    Any,
-    Tcp,
-    Udp,
-    Icmp,
-    IcmpV6,
+    Any = libc::IPPROTO_IP as u8,
+    Tcp = libc::IPPROTO_TCP as u8,
+    Udp = libc::IPPROTO_UDP as u8,
+    Icmp = libc::IPPROTO_ICMP as u8,
+    IcmpV6 = libc::IPPROTO_ICMPV6 as u8,
 }
 
 impl From<Proto> for u8 {
@@ -24,6 +27,21 @@ impl From<Proto> for u8 {
             Proto::Udp => libc::IPPROTO_UDP as u8,
             Proto::Icmp => libc::IPPROTO_ICMP as u8,
             Proto::IcmpV6 => libc::IPPROTO_ICMPV6 as u8,
+        }
+    }
+}
+
+impl TryFrom<u8> for Proto {
+    type Error = crate::Error;
+
+    fn try_from(proto: u8) -> Result<Self> {
+        match proto {
+            v if v == Proto::Any as u8 => Ok(Proto::Any),
+            v if v == Proto::Tcp as u8 => Ok(Proto::Tcp),
+            v if v == Proto::Udp as u8 => Ok(Proto::Udp),
+            v if v == Proto::Icmp as u8 => Ok(Proto::Icmp),
+            v if v == Proto::IcmpV6 as u8 => Ok(Proto::IcmpV6),
+            _ => Err(Error::from(ErrorInternal::InvalidTransportProtocol(proto))),
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,89 @@
+use std::fmt;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use crate::ffi::pfvar::pfsync_state_host;
+use crate::{ffi::pfvar::pfsync_state, Direction, Proto};
+use crate::{Error, ErrorInternal, Result};
+
+/// PF connection state created by a stateful rule
+#[derive(Clone)]
+pub struct State {
+    sync_state: pfsync_state,
+}
+
+// Manually derive `Debug` since `pfsync_state` contains unions.
+impl fmt::Debug for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("State")
+            .field("direction", &self.direction())
+            .field("proto", &self.proto())
+            .field("local_address", &self.local_address())
+            .field("remote_address", &self.remote_address())
+            .finish()
+    }
+}
+
+impl State {
+    /// Wrap a `pfsync_state` so that it can be accessed safely.
+    ///
+    /// # Safety
+    ///
+    /// All bytes in `sync_state` must be initialized.
+    pub(crate) unsafe fn new(sync_state: pfsync_state) -> State {
+        State { sync_state }
+    }
+
+    /// Return the direction for this state
+    pub fn direction(&self) -> Result<Direction> {
+        Direction::try_from(self.sync_state.direction)
+    }
+
+    /// Return the transport protocol for this state
+    pub fn proto(&self) -> Result<Proto> {
+        Proto::try_from(self.sync_state.proto)
+    }
+
+    /// Return the local socket address for this state
+    pub fn local_address(&self) -> Result<SocketAddr> {
+        // SAFETY: The address and port are initialized according to the contract of `Self::new`.
+        unsafe { parse_address(self.sync_state.af_lan, self.sync_state.lan) }
+    }
+
+    /// Return the remote socket address for this state
+    pub fn remote_address(&self) -> Result<SocketAddr> {
+        // SAFETY: The address and port are initialized according to the contract of `Self::new`.
+        unsafe { parse_address(self.sync_state.af_lan, self.sync_state.ext_lan) }
+    }
+
+    /// Return a reference to the inner `pfsync_state` state
+    pub(crate) fn as_raw(&self) -> &pfsync_state {
+        &self.sync_state
+    }
+}
+
+/// Parse an IP address and port from a `pfsync_sync_host`, normally provided by `pfsync_state`.
+///
+/// # Safety
+///
+/// `host` must contain a valid address and a port:
+/// * If `family == PF_INET`, then `host.addr.pfa._v4addr` must be initialized.
+/// * If `family == PF_INET6`, then `host.addr.pfa._v6addr` must be initialized.
+/// * `host.xport.port` must always be initialized.
+unsafe fn parse_address(family: u8, host: pfsync_state_host) -> Result<SocketAddr> {
+    let ip = match u32::from(family) {
+        crate::ffi::pfvar::PF_INET => {
+            // SAFETY: The caller has initialized this memory
+            Ipv4Addr::from(u32::from_be(unsafe { host.addr.pfa._v4addr.s_addr })).into()
+        }
+        crate::ffi::pfvar::PF_INET6 => {
+            // SAFETY: The caller has initialized this memory
+            Ipv6Addr::from(unsafe { host.addr.pfa._v6addr.__u6_addr.__u6_addr8 }).into()
+        }
+        _ => return Err(Error::from(ErrorInternal::InvalidAddressFamily(family))),
+    };
+
+    // SAFETY: The caller has initialized this memory
+    let port = u16::from_be(unsafe { host.xport.port });
+
+    Ok(SocketAddr::new(ip, port))
+}

--- a/tests/states.rs
+++ b/tests/states.rs
@@ -4,7 +4,11 @@ mod helper;
 
 use crate::helper::pfcli;
 use assert_matches::assert_matches;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
+use pfctl::{Direction, Proto, State};
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket},
+    time::Duration,
+};
 
 static ANCHOR_NAME: &str = "pfctl-rs.integration.testing.states";
 
@@ -91,4 +95,119 @@ test!(reset_ipv6_states_by_anchor {
     assert!(contains_subset(&pfcli::get_all_states(), &expected_states));
     assert_matches!(pf.clear_states(ANCHOR_NAME, pfctl::AnchorKind::Filter), Ok(2));
     assert!(not_contains_subset(&pfcli::get_all_states(), &expected_states));
+});
+
+#[derive(Debug, PartialEq)]
+struct ExpectedState {
+    proto: Proto,
+    direction: Direction,
+    local_address: SocketAddr,
+    remote_address: SocketAddr,
+}
+
+impl TryFrom<State> for ExpectedState {
+    type Error = pfctl::Error;
+
+    fn try_from(state: State) -> Result<Self, Self::Error> {
+        Ok(ExpectedState {
+            proto: state.proto()?,
+            direction: state.direction()?,
+            local_address: state.local_address()?,
+            remote_address: state.remote_address()?,
+        })
+    }
+}
+
+test!(kill_ipv4_state {
+    let mut pf = pfctl::PfCtl::new().unwrap();
+    let ipv4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    let server_addr = SocketAddr::new(ipv4, 13370);
+    let sender_addr = SocketAddr::new(ipv4, 13380);
+
+    pf.add_rule(ANCHOR_NAME, &rule_builder(server_addr)).unwrap();
+    send_udp_packet(sender_addr, server_addr);
+
+    std::thread::sleep(Duration::from_millis(1));
+
+    let states = pf.get_states().expect("Could not obtain states");
+
+    let expected_states = [
+        // UDP sender_addr -> server_addr
+        ExpectedState {
+            proto: Proto::Udp,
+            direction: Direction::Out,
+            local_address: sender_addr,
+            remote_address: server_addr,
+        },
+        // UDP server_addr <- sender_addr
+        ExpectedState {
+            proto: Proto::Udp,
+            direction: Direction::In,
+            local_address: server_addr,
+            remote_address: sender_addr,
+        },
+    ];
+
+    for expected_state in &expected_states {
+        let Some(state) = states.iter().find(|&state| matches!(ExpectedState::try_from(state.clone()), Ok(v) if v == *expected_state)) else {
+            panic!("cannot find state: {expected_state:?}");
+        };
+        assert_matches!(pf.kill_state(state), Ok(_));
+    }
+
+    let states = pf.get_states()
+        .expect("Could not obtain states")
+        .into_iter()
+        .filter_map(|state| ExpectedState::try_from(state).ok()).collect::<Vec<_>>();
+
+    for expected_state in &expected_states {
+        assert!(!states.contains(expected_state), "state should be removed");
+    }
+});
+
+test!(kill_ipv6_state {
+    let mut pf = pfctl::PfCtl::new().unwrap();
+    let ipv6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+    let server_addr = SocketAddr::new(ipv6, 13371);
+    let sender_addr = SocketAddr::new(ipv6, 13381);
+
+    pf.add_rule(ANCHOR_NAME, &rule_builder(server_addr)).unwrap();
+    send_udp_packet(sender_addr, server_addr);
+
+    std::thread::sleep(Duration::from_millis(1));
+
+    let states = pf.get_states().expect("Could not obtain states");
+
+    let expected_states = [
+        // UDP sender_addr -> server_addr
+        ExpectedState {
+            proto: Proto::Udp,
+            direction: Direction::Out,
+            local_address: sender_addr,
+            remote_address: server_addr,
+        },
+        // UDP server_addr <- sender_addr
+        ExpectedState {
+            proto: Proto::Udp,
+            direction: Direction::In,
+            local_address: server_addr,
+            remote_address: sender_addr,
+        },
+    ];
+
+    for expected_state in &expected_states {
+        let Some(state) = states.iter().find(|&state| matches!(ExpectedState::try_from(state.clone()), Ok(v) if v == *expected_state)) else {
+            panic!("cannot find state: {expected_state:?}");
+        };
+        assert_matches!(pf.kill_state(state), Ok(_));
+    }
+
+    let states = pf.get_states()
+        .expect("Could not obtain states")
+        .into_iter()
+        .filter_map(|state| ExpectedState::try_from(state).ok()).collect::<Vec<_>>();
+
+    for expected_state in &expected_states {
+        assert!(!states.contains(expected_state), "state should be removed");
+    }
 });


### PR DESCRIPTION
Add methods for listing and removing individual PF connection states. The existing methods (`clear_states`, and `clear_interface_states`) only allow states associated with a given anchor or interface to be removed, so these give more control.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/106)
<!-- Reviewable:end -->
