### PR TITLE
Remove error-chain and replace with handcrafted errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   `ipnetwork` is part of the public API.
 * Upgrade crate to Rust 2021 edition.
 * MSRV bumped to 1.69 due to use of `CStr::from_bytes_until_nul`.
+* Replace `error-chain` generated errors with manually implemented error types.
 
 ### Removed
 * Remove `PoolAddrList::to_palist` from the public API. It should never have been exposed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,34 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e772942dccdf11b368c31e044e4fca9189f80a773d2f0808379de65894cbf57"
 
 [[package]]
-name = "backtrace"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
-dependencies = [
- "backtrace-sys",
- "cfg-if 0.1.0",
- "libc",
- "rustc-demangle",
- "winapi",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3216d6e2b2c36c648a78afab0fdcb124d5365f7eb9b0895eab395549d76280d2"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,16 +75,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "backtrace",
- "version_check",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,7 +86,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -162,7 +124,6 @@ version = "0.4.6"
 dependencies = [
  "assert_matches",
  "derive_builder",
- "error-chain",
  "ioctl-sys",
  "ipnetwork",
  "libc",
@@ -187,12 +148,6 @@ checksum = "7ab938ebe6f1c82426b5fb82eaf10c3e3028c53deaa3fbe38f5904b37cf4d767"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
 
 [[package]]
 name = "scopeguard"
@@ -239,35 +194,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "winapi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ travis-ci = { repository = "mullvad/pfctl-rs" }
 
 
 [dependencies]
-error-chain = "0.12.4"
 ioctl-sys = "0.8.0"
 libc = "0.2.29"
 derive_builder = "0.9"

--- a/examples/enable.rs
+++ b/examples/enable.rs
@@ -15,7 +15,7 @@ fn main() {
     // Try to enable the firewall. Equivalent to the CLI command "pfctl -e".
     match pf.enable() {
         Ok(_) => println!("Enabled PF"),
-        Err(pfctl::Error(pfctl::ErrorKind::StateAlreadyActive, _)) => (),
+        Err(e) if e.kind() == pfctl::ErrorKind::StateAlreadyActive => (),
         err => err.expect("Unable to enable PF"),
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -19,11 +19,12 @@ macro_rules! ioctl_guard {
             let error_code = io_error
                 .raw_os_error()
                 .expect("Errors created with last_os_error should have errno");
-            let mut err = Err($crate::ErrorKind::IoctlError(io_error).into());
-            if error_code == $already_active {
-                err = err.chain_err(|| $crate::ErrorKind::StateAlreadyActive);
-            }
-            err
+
+            Err($crate::Error::from(if error_code == $already_active {
+                $crate::ErrorInternal::StateAlreadyActive
+            } else {
+                $crate::ErrorInternal::Ioctl(io_error)
+            }))
         } else {
             Ok(()) as $crate::Result<()>
         }

--- a/src/pooladdr.rs
+++ b/src/pooladdr.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     conversion::{CopyTo, TryCopyTo},
-    ffi, Interface, Ip, Result,
+    ffi, Interface, Ip,
 };
 use std::{mem, ptr, vec::Vec};
 
@@ -46,7 +46,9 @@ impl From<Ip> for PoolAddr {
 }
 
 impl TryCopyTo<ffi::pfvar::pf_pooladdr> for PoolAddr {
-    fn try_copy_to(&self, pf_pooladdr: &mut ffi::pfvar::pf_pooladdr) -> Result<()> {
+    type Error = crate::Error;
+
+    fn try_copy_to(&self, pf_pooladdr: &mut ffi::pfvar::pf_pooladdr) -> Result<(), Self::Error> {
         self.interface.try_copy_to(&mut pf_pooladdr.ifname)?;
         self.ip.copy_to(&mut pf_pooladdr.addr);
         Ok(())
@@ -67,7 +69,7 @@ pub struct PoolAddrList {
 }
 
 impl PoolAddrList {
-    pub fn new(pool_addrs: &[PoolAddr]) -> Result<Self> {
+    pub fn new(pool_addrs: &[PoolAddr]) -> Result<Self, crate::Error> {
         let mut pool = Self::init_pool(pool_addrs)?;
         Self::link_elements(&mut pool);
         let list = Self::create_palist(&mut pool);
@@ -88,7 +90,7 @@ impl PoolAddrList {
         self.list
     }
 
-    fn init_pool(pool_addrs: &[PoolAddr]) -> Result<Vec<ffi::pfvar::pf_pooladdr>> {
+    fn init_pool(pool_addrs: &[PoolAddr]) -> Result<Vec<ffi::pfvar::pf_pooladdr>, crate::Error> {
         let mut pool = Vec::with_capacity(pool_addrs.len());
         for pool_addr in pool_addrs {
             let mut pf_pooladdr = unsafe { mem::zeroed::<ffi::pfvar::pf_pooladdr>() };

--- a/src/rule/endpoint.rs
+++ b/src/rule/endpoint.rs
@@ -9,7 +9,7 @@
 use super::{AddrFamily, Ip, Port};
 use crate::{
     conversion::{CopyTo, TryCopyTo},
-    ffi, Result,
+    ffi,
 };
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
@@ -92,7 +92,9 @@ impl From<SocketAddr> for Endpoint {
 }
 
 impl TryCopyTo<ffi::pfvar::pf_rule_addr> for Endpoint {
-    fn try_copy_to(&self, pf_rule_addr: &mut ffi::pfvar::pf_rule_addr) -> Result<()> {
+    type Error = crate::Error;
+
+    fn try_copy_to(&self, pf_rule_addr: &mut ffi::pfvar::pf_rule_addr) -> crate::Result<()> {
         self.ip.copy_to(&mut pf_rule_addr.addr);
         self.port
             .try_copy_to(unsafe { &mut pf_rule_addr.xport.range })?;

--- a/src/rule/interface.rs
+++ b/src/rule/interface.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::{conversion::TryCopyTo, Result};
+use crate::conversion::TryCopyTo;
+use crate::{Error, ErrorInternal};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InterfaceName(String);
@@ -31,11 +32,14 @@ impl<T: AsRef<str>> From<T> for Interface {
 }
 
 impl TryCopyTo<[i8]> for Interface {
-    fn try_copy_to(&self, dst: &mut [i8]) -> Result<()> {
+    type Error = crate::Error;
+
+    fn try_copy_to(&self, dst: &mut [i8]) -> Result<(), Self::Error> {
         match *self {
             Interface::Any => "",
             Interface::Name(InterfaceName(ref name)) => &name[..],
         }
         .try_copy_to(dst)
+        .map_err(|reason| Error::from(ErrorInternal::InvalidInterfaceName(reason)))
     }
 }

--- a/tests/anchors.rs
+++ b/tests/anchors.rs
@@ -24,7 +24,7 @@ test!(add_filter_anchor {
 
     assert_matches!(
         pf.add_anchor(&anchor_name, pfctl::AnchorKind::Filter),
-        Err(pfctl::Error(pfctl::ErrorKind::StateAlreadyActive, _))
+        Err(e) if e.kind() == pfctl::ErrorKind::StateAlreadyActive
     );
     assert_matches!(pf.try_add_anchor(&anchor_name, pfctl::AnchorKind::Filter), Ok(()));
 });
@@ -41,7 +41,7 @@ test!(remove_filter_anchor {
 
     assert_matches!(
         pf.remove_anchor(&anchor_name, pfctl::AnchorKind::Filter),
-        Err(pfctl::Error(pfctl::ErrorKind::AnchorDoesNotExist, _))
+        Err(e) if e.kind() == pfctl::ErrorKind::AnchorDoesNotExist
     );
     assert_matches!(pf.try_remove_anchor(&anchor_name, pfctl::AnchorKind::Filter), Ok(()));
 });

--- a/tests/enable_disable.rs
+++ b/tests/enable_disable.rs
@@ -14,7 +14,7 @@ test!(enable_pf {
     pfcli::disable_firewall();
     assert_matches!(pf.enable(), Ok(()));
     assert!(pfcli::is_enabled());
-    assert_matches!(pf.enable(), Err(pfctl::Error(pfctl::ErrorKind::StateAlreadyActive, _)));
+    assert_matches!(pf.enable(), Err(e) if e.kind() == pfctl::ErrorKind::StateAlreadyActive);
     assert_matches!(pf.try_enable(), Ok(()));
     assert!(pfcli::is_enabled());
 });
@@ -25,7 +25,7 @@ test!(disable_pf {
     pfcli::enable_firewall();
     assert_matches!(pf.disable(), Ok(()));
     assert!(!pfcli::is_enabled());
-    assert_matches!(pf.disable(), Err(pfctl::Error(pfctl::ErrorKind::StateAlreadyActive, _)));
+    assert_matches!(pf.disable(), Err(e) if e.kind() == pfctl::ErrorKind::StateAlreadyActive);
     assert_matches!(pf.try_disable(), Ok(()));
     assert!(!pfcli::is_enabled());
 });


### PR DESCRIPTION
This changes the API of the error a lot, and the returned error chain in many calls into this library.

This supersedes #88. I'm not saying we absolutely have to stay away from `thiserror`. But I had some questions about the details in that PR so I decided to try my own approach. And I like this approach. The error was easy to implement manually.

I have tried these changes out in our main app, and it does not create any trouble. We don't really match against the errors anywhere, so it just compiles with no changes. The error chain will print a bit differently if we run into an error, but hopefully the changes or not for the worse.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/107)
<!-- Reviewable:end -->
