### PR TITLE
Upgrade `derive-builder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 * Upgrade crate to Rust 2021 edition.
 * MSRV bumped to 1.69 due to use of `CStr::from_bytes_until_nul`.
 * Replace `error-chain` generated errors with manually implemented error types.
+* Remove `build_internal` methods on `FilterRuleBuilder` and `RedirectRuleBuilder`.
+  This was never supposed to be public, but a side effect of using `derive-builder`.
 
 ### Removed
 * Remove `PoolAddrList::to_palist` from the public API. It should never have been exposed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "darling"
-version = "0.10.2"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.10.2"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.10.2"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
@@ -51,34 +51,40 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.9.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
+checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
 dependencies = [
  "darling",
- "derive_builder_core",
  "proc-macro2",
  "quote",
  "syn",
 ]
 
 [[package]]
-name = "derive_builder_core"
-version = "0.9.0"
+name = "derive_builder_macro"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
+checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
- "darling",
- "proc-macro2",
- "quote",
+ "derive_builder_core",
  "syn",
 ]
 
 [[package]]
 name = "fnv"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
@@ -93,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "ident_case"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9826188e666f2ed92071d2dadef6edc430b11b158b5b2b3f4babbcc891eaaa"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "ioctl-sys"
@@ -133,18 +139,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.0"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f287c234c9b2d0308d692dee5c449c1a171167a6f8150f7cf2a49d8fd96967"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.0"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab938ebe6f1c82426b5fb82eaf10c3e3028c53deaa3fbe38f5904b37cf4d767"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -163,26 +169,26 @@ checksum = "369633cfe0f0bde1dfc037fb6c5a329d46586a31f981bed14d87487a3439ae37"
 
 [[package]]
 name = "strsim"
-version = "0.9.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7be23478587f30ca7b4b423b6bee7baf5b6986c1e511bf1904a984cb6105621"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "1.0.1"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863ecbce06044c8380458360b4146d7372edadfedd77f120ba8c193da427b708"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.0"
+name = "unicode-ident"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "mullvad/pfctl-rs" }
 [dependencies]
 ioctl-sys = "0.8.0"
 libc = "0.2.29"
-derive_builder = "0.9"
+derive_builder = "0.20"
 ipnetwork = "0.20.0"
 
 [dev-dependencies]

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -10,7 +10,6 @@ use crate::{
     conversion::{CopyTo, TryCopyTo},
     ffi, Error, ErrorInternal, Result,
 };
-use derive_builder::Builder;
 use ipnetwork::IpNetwork;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -59,9 +58,9 @@ pub use self::rule_log::*;
 mod uid;
 pub use self::uid::*;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_builder::Builder)]
 #[builder(setter(into))]
-#[builder(build_fn(name = "build_internal"))]
+#[builder(build_fn(error = "Error"))]
 pub struct FilterRule {
     action: FilterRuleAction,
     #[builder(default)]
@@ -94,13 +93,6 @@ pub struct FilterRule {
     group: Gid,
     #[builder(default)]
     icmp_type: Option<IcmpType>,
-}
-
-impl FilterRuleBuilder {
-    pub fn build(&self) -> Result<FilterRule> {
-        self.build_internal()
-            .map_err(|e| ErrorInternal::InvalidRuleCombination(e.to_string()).into())
-    }
 }
 
 impl FilterRule {
@@ -167,9 +159,9 @@ impl TryCopyTo<ffi::pfvar::pf_rule> for FilterRule {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_builder::Builder)]
 #[builder(setter(into))]
-#[builder(build_fn(name = "build_internal"))]
+#[builder(build_fn(error = "Error"))]
 pub struct RedirectRule {
     action: RedirectRuleAction,
     #[builder(default)]
@@ -195,13 +187,6 @@ pub struct RedirectRule {
     #[builder(default)]
     group: Gid,
     redirect_to: Endpoint,
-}
-
-impl RedirectRuleBuilder {
-    pub fn build(&self) -> Result<RedirectRule> {
-        self.build_internal()
-            .map_err(|e| ErrorInternal::InvalidRuleCombination(e.to_string()).into())
-    }
 }
 
 impl RedirectRule {

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -99,7 +99,7 @@ pub struct FilterRule {
 impl FilterRuleBuilder {
     pub fn build(&self) -> Result<FilterRule> {
         self.build_internal()
-            .map_err(|e| ErrorInternal::InvalidRuleCombination(e).into())
+            .map_err(|e| ErrorInternal::InvalidRuleCombination(e.to_string()).into())
     }
 }
 
@@ -200,7 +200,7 @@ pub struct RedirectRule {
 impl RedirectRuleBuilder {
     pub fn build(&self) -> Result<RedirectRule> {
         self.build_internal()
-            .map_err(|e| ErrorInternal::InvalidRuleCombination(e).into())
+            .map_err(|e| ErrorInternal::InvalidRuleCombination(e.to_string()).into())
     }
 }
 


### PR DESCRIPTION
Upgrade the `derive-builder` dependency to the latest version. This improves the API of the generated builders. It removes the need to expose `build_internal` and write our own `build` method. Instead via the `From` impl between their error variant and ours, we can now have `derive-builder` directly generate a `build` method returning our own `Error` type directly.

Upgrades a lot of dependencies. Does not really shrink the dependency tree, but upgrades it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/108)
<!-- Reviewable:end -->
