### PR TITLE
Upgrade `ipnetwork` to 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,12 +339,9 @@ checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "ipnetwork"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
+checksum = "2f7d1e51dceb94e362a3bd4849c5b8b44989faf8b66998fc0a44ff11923393c9"
 
 [[package]]
 name = "libc"
@@ -454,12 +451,6 @@ name = "scopeguard"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
-
-[[package]]
-name = "serde"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369633cfe0f0bde1dfc037fb6c5a329d46586a31f981bed14d87487a3439ae37"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "mullvad/pfctl-rs" }
 ioctl-sys = "0.8.0"
 libc = "0.2.29"
 derive_builder = "0.20"
-ipnetwork = "0.20.0"
+ipnetwork = "0.21"
 
 [dev-dependencies]
 assert_matches = "1.1.0"


### PR DESCRIPTION
Upgrade ipnetwork to 0.21. This PR also unpins the patch version of `ipnetwork`.

Other than including some bugfixes this release also removes `serde` as a default dependency, making it opt-in instead. `pfctl-rs` does not use `serde`, so this is a small benefit  we get by upgrading `ipnetwork`.