### PR TITLE
Fix `clippy` lint `needless_lifetimes`

### DIFF
--- a/src/rule/rule_log.rs
+++ b/src/rule/rule_log.rs
@@ -45,7 +45,7 @@ impl From<RuleLog> for RuleLogSet {
     }
 }
 
-impl<'a> From<&'a RuleLogSet> for u8 {
+impl From<&RuleLogSet> for u8 {
     fn from(set: &RuleLogSet) -> Self {
         set.0.iter().fold(0, |acc, &x| (acc | u8::from(x)))
     }

--- a/src/rule/tcp_flags.rs
+++ b/src/rule/tcp_flags.rs
@@ -41,7 +41,7 @@ impl From<TcpFlag> for u8 {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct TcpFlagSet(Vec<TcpFlag>);
 
-impl<'a> From<&'a TcpFlagSet> for u8 {
+impl From<&TcpFlagSet> for u8 {
     fn from(set: &TcpFlagSet) -> Self {
         set.0.iter().fold(0, |acc, &x| (acc | u8::from(x)))
     }


### PR DESCRIPTION
This PR simply elides some lifetimes where they can be inferred.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/122)
<!-- Reviewable:end -->
