### PR TITLE
Run tests on Intel macOS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,10 @@ jobs:
       matrix:
         # Keep MSRV in sync with rust-version in Cargo.toml as much as possible.
         rust: [stable, beta, nightly, 1.77.0]
-    runs-on: macos-latest
+        # NOTE: macos-13 is using Intel Mac as of 2025-05-20:
+        #       https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners
+        os: [macos-13, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Run tests on macOS 13. This runner ensures we test Intel macOS: https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/125)
<!-- Reviewable:end -->
