### PR TITLE
Fix unnecessary parens

### DIFF
--- a/src/rule/rule_log.rs
+++ b/src/rule/rule_log.rs
@@ -47,6 +47,6 @@ impl From<RuleLog> for RuleLogSet {
 
 impl From<&RuleLogSet> for u8 {
     fn from(set: &RuleLogSet) -> Self {
-        set.0.iter().fold(0, |acc, &x| (acc | u8::from(x)))
+        set.0.iter().fold(0, |acc, &x| acc | u8::from(x))
     }
 }

--- a/src/rule/tcp_flags.rs
+++ b/src/rule/tcp_flags.rs
@@ -43,7 +43,7 @@ pub struct TcpFlagSet(Vec<TcpFlag>);
 
 impl From<&TcpFlagSet> for u8 {
     fn from(set: &TcpFlagSet) -> Self {
-        set.0.iter().fold(0, |acc, &x| (acc | u8::from(x)))
+        set.0.iter().fold(0, |acc, &x| acc | u8::from(x))
     }
 }
 


### PR DESCRIPTION
Applied a fix based on clippy suggestion

``` 
warning: unnecessary parentheses around closure body
  --> src/rule/tcp_flags.rs:46:40
   |
46 |         set.0.iter().fold(0, |acc, &x| (acc | u8::from(x)))
   |                                        ^                 ^
   |
   = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
   |
46 -         set.0.iter().fold(0, |acc, &x| (acc | u8::from(x)))
46 +         set.0.iter().fold(0, |acc, &x| acc | u8::from(x))
   |

warning: unnecessary parentheses around closure body
  --> src/rule/rule_log.rs:50:40
   |
50 |         set.0.iter().fold(0, |acc, &x| (acc | u8::from(x)))
   |                                        ^                 ^
   |
help: remove these parentheses
   |
50 -         set.0.iter().fold(0, |acc, &x| (acc | u8::from(x)))
50 +         set.0.iter().fold(0, |acc, &x| acc | u8::from(x))
   |

warning: `pfctl` (lib) generated 2 warnings (run `cargo fix --lib -p pfctl` to apply 2 suggestions)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.45s
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/126)
<!-- Reviewable:end -->
