### PR TITLE
fix(rule): Allow direct add_rule for route rules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,12 +340,23 @@ impl PfCtl {
     pub fn add_rule(&mut self, anchor: &str, rule: &FilterRule) -> Result<()> {
         let mut pfioc_rule = ffi::pfvar::pfioc_rule::new_zeroed();
 
-        pfioc_rule.pool_ticket = utils::get_pool_ticket(self.fd())?;
+        let pool_ticket = utils::get_pool_ticket(self.fd())?;
         pfioc_rule.ticket = utils::get_ticket(self.fd(), anchor, AnchorKind::Filter)?;
         utils::copy_anchor_name(anchor, &mut pfioc_rule.anchor[..])?;
         rule.try_copy_to(&mut pfioc_rule.rule)?;
 
+        if let Some(pool_addr) = rule.get_route().get_pool_addr() {
+            // Register pool address with firewall
+            utils::add_pool_address(self.fd(), pool_addr.clone(), pool_ticket)?;
+
+            // copy address pool in pf_rule
+            let pool = PoolAddrList::new(core::slice::from_ref(pool_addr))?;
+            pfioc_rule.rule.rpool.list = unsafe { pool.to_palist() };
+        };
+
+        pfioc_rule.pool_ticket = pool_ticket;
         pfioc_rule.action = ffi::pfvar::PF_CHANGE_ADD_TAIL as u32;
+
         ioctl_guard!(ffi::pf_change_rule(self.fd(), &mut pfioc_rule))
     }
 

--- a/tests/filter_rules.rs
+++ b/tests/filter_rules.rs
@@ -129,9 +129,6 @@ test!(drop_by_interface_rule {
     );
 });
 
-// TODO(andrej):
-// currently only transactions support Route. We need to unify code
-// in lib.rs for adding single rule and code in transaction.rs.
 test!(pass_out_route_rule {
     let rule = pfctl::FilterRuleBuilder::default()
         .action(pfctl::FilterRuleAction::Pass)
@@ -153,6 +150,34 @@ test!(pass_out_route_rule {
     trans.add_change(ANCHOR_NAME, change);
 
     assert_matches!(trans.commit(), Ok(()));
+    assert_eq!(
+        pfcli::get_rules(ANCHOR_NAME),
+        &[
+            "pass out route-to (lo0 127.0.0.1) inet proto udp \
+            from 1.2.3.4 to any port = 53 no state"
+        ]
+    );
+});
+
+// Test direct add_rule() API with route_to
+test!(pass_out_route_rule_with_add_rule {
+    let mut pf = pfctl::PfCtl::new().unwrap();
+
+    let rule = pfctl::FilterRuleBuilder::default()
+        .action(pfctl::FilterRuleAction::Pass)
+        .direction(pfctl::Direction::Out)
+        .route(
+            pfctl::Route::RouteTo(
+                pfctl::PoolAddr::new("lo0", Ipv4Addr::new(127, 0, 0, 1))
+            )
+        )
+        .proto(pfctl::Proto::Udp)
+        .from(Ipv4Addr::new(1, 2, 3, 4))
+        .to(pfctl::Port::from(53))
+        .build()
+        .unwrap();
+
+    assert_matches!(pf.add_rule(ANCHOR_NAME, &rule), Ok(()));
     assert_eq!(
         pfcli::get_rules(ANCHOR_NAME),
         &[


### PR DESCRIPTION
As documented in the inline TODO which was removed, it was not possible to use `add_rule` directly for route rules. This would lead to ioctl errors.

This PR follows the same approach as the redirect and nat-rule handlers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/132)
<!-- Reviewable:end -->
