### PR TITLE
Add `cargo shear` to CI to check for unused dependencies

### DIFF
--- a/.github/workflows/cargo-shear.yml
+++ b/.github/workflows/cargo-shear.yml
@@ -1,0 +1,23 @@
+---
+name: Unused dependencies
+on:
+  pull_request:
+    paths:
+      - .github/workflows/cargo-shear.yml
+      - "**/*.rs"
+      - "**/Cargo.toml"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  cargo-shear:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-shear
+        uses: taiki-e/install-action@cargo-shear
+
+      - name: Run cargo shear
+        run: cargo shear

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,10 @@ uuid = { version = "1.8.0", features = ["v4"] }
 scopeguard = "1.0"
 tun = "0.7.4"
 
-# Transitive dependencies with incorrect semver use
-# or that no longer compile for some reason.
-# All of these belong to 'tun'
+# These are here because `tun` specify their lower bounds on these dependencies.
+# So for our `minimal-versions` CI job to pass, we need these here.
+# Fixed in tun in https://github.com/meh/rust-tun/pull/146.
+# These can be removed once those fixes are released and we are able to upgrade
+# to the latest version.
 ipnet = "2.6.0"
 log = "0.4.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,8 @@ tun = "0.7.4"
 # to the latest version.
 ipnet = "2.6.0"
 log = "0.4.22"
+
+
+[package.metadata.cargo-shear]
+# See comment on these dependencies. Can be un-ignored once we upgrade `tun`
+ignored = ["ipnet", "log"]


### PR DESCRIPTION
Adopting our standardized `cargo shear` CI job to catch unused dependencies.

Things are a bit ugly/special here because of the ugly catch22 created between 1. problem in tun. 2. minimal-dependencies CI. 3. cargo shear CI. :sweat_smile: But I think working around it with an ignore is good enough for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/133)
<!-- Reviewable:end -->
