### PR TITLE
Fix PF address pool list lifetimes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,15 +363,19 @@ impl PfCtl {
 
         let pool_ticket = utils::get_pool_ticket(self.fd())?;
 
-        if let Some(nat_to) = rule.get_nat_to() {
+        // Keep the backing storage alive until PF has copied the rule below.
+        let nat_pool = if let Some(nat_to) = rule.get_nat_to() {
             // register NAT address in newly created address pool
             utils::add_pool_address(self.fd(), nat_to.ip(), pool_ticket)?;
 
             // copy address pool in pf_rule
-            let nat_pool = nat_to.ip().to_pool_addr_list()?;
-            pfioc_rule.rule.rpool.list = unsafe { nat_pool.to_palist() };
+            let mut nat_pool = nat_to.ip().to_pool_addr_list()?;
+            nat_pool.write_to(&mut pfioc_rule.rule.rpool.list);
             nat_to.port().try_copy_to(&mut pfioc_rule.rule.rpool)?;
-        }
+            Some(nat_pool)
+        } else {
+            None
+        };
 
         // set tickets
         pfioc_rule.pool_ticket = pool_ticket;
@@ -379,7 +383,9 @@ impl PfCtl {
 
         // append rule
         pfioc_rule.action = ffi::pfvar::PF_CHANGE_ADD_TAIL as u32;
-        ioctl_guard!(ffi::pf_change_rule(self.fd(), &mut pfioc_rule))
+        ioctl_guard!(ffi::pf_change_rule(self.fd(), &mut pfioc_rule))?;
+        drop(nat_pool);
+        Ok(())
     }
 
     pub fn add_redirect_rule(&mut self, anchor: &str, rule: &RedirectRule) -> Result<()> {
@@ -394,8 +400,8 @@ impl PfCtl {
         utils::add_pool_address(self.fd(), redirect_to.ip(), pool_ticket)?;
 
         // copy address pool in pf_rule
-        let redirect_pool = redirect_to.ip().to_pool_addr_list()?;
-        pfioc_rule.rule.rpool.list = unsafe { redirect_pool.to_palist() };
+        let mut redirect_pool = redirect_to.ip().to_pool_addr_list()?;
+        redirect_pool.write_to(&mut pfioc_rule.rule.rpool.list);
         redirect_to.port().try_copy_to(&mut pfioc_rule.rule.rpool)?;
 
         // set tickets
@@ -404,7 +410,9 @@ impl PfCtl {
 
         // append rule
         pfioc_rule.action = ffi::pfvar::PF_CHANGE_ADD_TAIL as u32;
-        ioctl_guard!(ffi::pf_change_rule(self.fd(), &mut pfioc_rule))
+        ioctl_guard!(ffi::pf_change_rule(self.fd(), &mut pfioc_rule))?;
+        drop(redirect_pool);
+        Ok(())
     }
 
     pub fn add_scrub_rule(&mut self, anchor: &str, rule: &ScrubRule) -> Result<()> {

--- a/src/pooladdr.rs
+++ b/src/pooladdr.rs
@@ -62,35 +62,51 @@ impl TryCopyTo<ffi::pfvar::pf_pooladdr> for PoolAddr {
 ///
 /// See pf_rule.rpool.list for more info.
 ///
-/// This class retains the array of `pf_pooladdr` to make sure that pointers used in pf_palist
-/// reference the valid memory.
+/// Owns the `pf_pooladdr` storage referenced by a PF address-pool list.
 ///
-/// One should never use `pf_palist` produced by this class past the lifetime expiration of it.
+/// The caller must retain this value until the ioctl consuming the populated
+/// `pf_palist` has returned.
 pub struct PoolAddrList {
-    list: ffi::pfvar::pf_palist,
-    _pool: Box<[ffi::pfvar::pf_pooladdr]>,
+    pool: Box<[ffi::pfvar::pf_pooladdr]>,
 }
 
 impl PoolAddrList {
     pub fn new(pool_addrs: &[PoolAddr]) -> Result<Self, crate::Error> {
-        let mut pool = Self::init_pool(pool_addrs)?;
+        let mut pool = Self::init_pool(pool_addrs)?.into_boxed_slice();
         Self::link_elements(&mut pool);
-        let list = Self::create_palist(&mut pool);
-
-        Ok(PoolAddrList {
-            list,
-            _pool: pool.into_boxed_slice(),
-        })
+        Ok(PoolAddrList { pool })
     }
 
-    /// Returns a copy of inner pf_palist linked list.
-    ///
-    /// # Safety
-    ///
-    /// Returned object has pointers into the `PoolAddrList` it was created from. So the
-    /// `PoolAddrList` must outlive the returned `pf_palist`
-    pub(crate) unsafe fn to_palist(&self) -> ffi::pfvar::pf_palist {
-        self.list
+    /// Writes a BSD tail queue backed by this object's stable heap storage.
+    pub(crate) fn write_to(&mut self, list: &mut ffi::pfvar::pf_palist) {
+        *list = ffi::pfvar::pf_palist::new_zeroed();
+        if self.pool.is_empty() {
+            list.tqh_last = &mut list.tqh_first;
+            return;
+        }
+
+        let pool = self.pool.as_mut_ptr();
+        unsafe {
+            let first = pool;
+            let last = pool.add(self.pool.len() - 1);
+            list.tqh_first = first;
+            list.tqh_last = &mut (*last).entries.tqe_next;
+            (*first).entries.tqe_prev = &mut list.tqh_first;
+            (*last).entries.tqe_next = ptr::null_mut();
+        }
+    }
+
+    /// Links adjacent pool entries in their stable heap allocation.
+    fn link_elements(pool: &mut [ffi::pfvar::pf_pooladdr]) {
+        let entries = pool.as_mut_ptr();
+        unsafe {
+            for index in 1..pool.len() {
+                let previous = entries.add(index - 1);
+                let current = entries.add(index);
+                (*previous).entries.tqe_next = current;
+                (*current).entries.tqe_prev = &mut (*previous).entries.tqe_next;
+            }
+        }
     }
 
     fn init_pool(pool_addrs: &[PoolAddr]) -> Result<Vec<ffi::pfvar::pf_pooladdr>, crate::Error> {
@@ -102,30 +118,30 @@ impl PoolAddrList {
         }
         Ok(pool)
     }
+}
 
-    fn link_elements(pool: &mut [ffi::pfvar::pf_pooladdr]) {
-        for i in 1..pool.len() {
-            let mut elem1 = pool[i - 1];
-            let mut elem2 = pool[i];
-            elem1.entries.tqe_next = &mut elem2;
-            elem2.entries.tqe_prev = &mut elem1.entries.tqe_next;
-        }
-    }
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    fn create_palist(pool: &mut [ffi::pfvar::pf_pooladdr]) -> ffi::pfvar::pf_palist {
-        let mut list = ffi::pfvar::pf_palist::new_zeroed();
-        if !pool.is_empty() {
-            let mut first_elem = pool[0];
-            let mut last_elem = pool[pool.len() - 1];
+    #[test]
+    fn new_links_the_owned_pool_storage() {
+        let mut pool = PoolAddrList::new(&[
+            PoolAddr::from(Ip::Any),
+            PoolAddr::from(Ip::from(std::net::Ipv4Addr::new(192, 0, 2, 1))),
+        ])
+        .unwrap();
 
-            list.tqh_first = &mut first_elem;
-            first_elem.entries.tqe_prev = &mut list.tqh_first;
-            last_elem.entries.tqe_next = ptr::null_mut();
-            list.tqh_last = &mut last_elem.entries.tqe_next;
-        } else {
-            list.tqh_first = ptr::null_mut();
-            list.tqh_last = &mut list.tqh_first;
-        }
-        list
+        let first = pool.pool.as_mut_ptr();
+        let second = unsafe { first.add(1) };
+        let first_next = unsafe { std::ptr::addr_of_mut!((*first).entries.tqe_next) };
+        assert_eq!(unsafe { (*first).entries.tqe_next }, second);
+        assert_eq!(unsafe { (*second).entries.tqe_prev }, first_next);
+
+        let mut palist = ffi::pfvar::pf_palist::new_zeroed();
+        pool.write_to(&mut palist);
+        let second_next = unsafe { std::ptr::addr_of_mut!((*second).entries.tqe_next) };
+        assert_eq!(palist.tqh_first, first);
+        assert_eq!(palist.tqh_last, second_next);
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -173,12 +173,12 @@ impl Transaction {
 
         // setup address pool for route if routing is enabled on the rule.
         // Save the list so the memory is valid until end of method.
-        let _pool_addr_list = if let Some(pool_addr) = rule.get_route().get_pool_addr() {
+        let pool_addr_list = if let Some(pool_addr) = rule.get_route().get_pool_addr() {
             // register pool address with firewall
             utils::add_pool_address(fd, pool_addr.clone(), pool_ticket)?;
-            let pool_addr_list = PoolAddrList::new(slice::from_ref(pool_addr))?;
+            let mut pool_addr_list = PoolAddrList::new(slice::from_ref(pool_addr))?;
 
-            pfioc_rule.rule.rpool.list = unsafe { pool_addr_list.to_palist() };
+            pool_addr_list.write_to(&mut pfioc_rule.rule.rpool.list);
             Some(pool_addr_list)
         } else {
             None
@@ -190,7 +190,7 @@ impl Transaction {
 
         // add rule into transaction
         ioctl_guard!(ffi::pf_add_rule(fd, &mut pfioc_rule))?;
-        drop(_pool_addr_list);
+        drop(pool_addr_list);
         Ok(())
     }
 
@@ -203,22 +203,28 @@ impl Transaction {
 
         let pool_ticket = utils::get_pool_ticket(fd)?;
 
-        if let Some(nat_to) = rule.get_nat_to() {
+        // Keep the backing storage alive until PF has copied the rule below.
+        let nat_pool = if let Some(nat_to) = rule.get_nat_to() {
             // register NAT address in newly created address pool
             utils::add_pool_address(fd, nat_to.ip(), pool_ticket)?;
 
             // copy address pool in pf_rule
-            let nat_pool = nat_to.ip().to_pool_addr_list()?;
-            pfioc_rule.rule.rpool.list = unsafe { nat_pool.to_palist() };
+            let mut nat_pool = nat_to.ip().to_pool_addr_list()?;
+            nat_pool.write_to(&mut pfioc_rule.rule.rpool.list);
             nat_to.port().try_copy_to(&mut pfioc_rule.rule.rpool)?;
-        }
+            Some(nat_pool)
+        } else {
+            None
+        };
 
         // set tickets
         pfioc_rule.pool_ticket = pool_ticket;
         pfioc_rule.ticket = ticket;
 
         // add rule into transaction
-        ioctl_guard!(ffi::pf_add_rule(fd, &mut pfioc_rule))
+        ioctl_guard!(ffi::pf_add_rule(fd, &mut pfioc_rule))?;
+        drop(nat_pool);
+        Ok(())
     }
 
     /// Internal helper to add redirect rule into transaction
@@ -234,8 +240,8 @@ impl Transaction {
         utils::add_pool_address(fd, redirect_to.ip(), pool_ticket)?;
 
         // copy address pool in pf_rule
-        let redirect_pool = redirect_to.ip().to_pool_addr_list()?;
-        pfioc_rule.rule.rpool.list = unsafe { redirect_pool.to_palist() };
+        let mut redirect_pool = redirect_to.ip().to_pool_addr_list()?;
+        redirect_pool.write_to(&mut pfioc_rule.rule.rpool.list);
         redirect_to.port().try_copy_to(&mut pfioc_rule.rule.rpool)?;
 
         // set tickets
@@ -243,7 +249,9 @@ impl Transaction {
         pfioc_rule.ticket = ticket;
 
         // add rule into transaction
-        ioctl_guard!(ffi::pf_add_rule(fd, &mut pfioc_rule))
+        ioctl_guard!(ffi::pf_add_rule(fd, &mut pfioc_rule))?;
+        drop(redirect_pool);
+        Ok(())
     }
 
     /// Internal helper to add scrub rule into transaction


### PR DESCRIPTION
Build links between adjacent pf_pooladdr entries during PoolAddrList construction, after the entries have been placed in stable heap storage. Bind only the position-dependent PF list head and tail pointers when the final rule list is available. This preserves the previous construction semantics while avoiding pointers to stack copies. Extend the regression test to verify the element links are present immediately after construction.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/pfctl-rs/134)
<!-- Reviewable:end -->
